### PR TITLE
fix(tests): increase timeout and delay for Debounce test

### DIFF
--- a/tests/MultiLock.Tests/LeadershipExtensionMethodsTests.cs
+++ b/tests/MultiLock.Tests/LeadershipExtensionMethodsTests.cs
@@ -509,7 +509,7 @@ public class LeadershipExtensionMethodsTests
         var service = (LeaderElectionService)services.GetRequiredService<ILeaderElectionService>();
         var events = new List<LeadershipChangedEventArgs>();
         object eventsLock = new();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var subscriberRegistered = new TaskCompletionSource();
 
         // Act - Start listening BEFORE starting service
@@ -535,9 +535,10 @@ public class LeadershipExtensionMethodsTests
         await service.StopAsync(cts.Token);
 
         // Wait for debounce delay and event processing - debounce needs time to process events
-        // Each event is delayed by 100ms, so we need at least 200ms for 2 events plus processing time
-        await Task.Delay(TimeSpan.FromMilliseconds(300), cts.Token);
-        await TestHelpers.WaitForConditionAsync(() => events.Count >= 1, TimeSpan.FromSeconds(5), cts.Token, eventsLock);
+        // The debounce waits 100ms after each event, so we need significant time for 2 events
+        // plus the time for the stream to complete after the service stops
+        await Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
+        await TestHelpers.WaitForConditionAsync(() => events.Count >= 1, TimeSpan.FromSeconds(10), cts.Token, eventsLock);
 
         // Cleanup - Cancel and wait for event task to complete before asserting
         await cts.CancelAsync();


### PR DESCRIPTION
The Debounce extension delays each event by the specified timespan (100ms), so we need to allow enough time for the debounced events to be processed before checking the results. Increased the timeout from 5s to 15s and the delay from 150ms to 500ms to accommodate slower CI environments.


