### PR TITLE
feat: add distributed counting semaphore with multi-provider support

### DIFF
--- a/MultiLock.slnx
+++ b/MultiLock.slnx
@@ -1,21 +1,24 @@
 <Solution>
   <Folder Name="/Providers/">
-    <Project Path="src\Providers\MultiLock.AzureBlobStorage\MultiLock.AzureBlobStorage.csproj" Type="Classic C#" />
-    <Project Path="src\Providers\MultiLock.Consul\MultiLock.Consul.csproj" Type="Classic C#" />
-    <Project Path="src\Providers\MultiLock.FileSystem\MultiLock.FileSystem.csproj" Type="Classic C#" />
-    <Project Path="src\Providers\MultiLock.InMemory\MultiLock.InMemory.csproj" Type="Classic C#" />
-    <Project Path="src\Providers\MultiLock.PostgreSQL\MultiLock.PostgreSQL.csproj" Type="Classic C#" />
-    <Project Path="src\Providers\MultiLock.Redis\MultiLock.Redis.csproj" Type="Classic C#" />
-    <Project Path="src\Providers\MultiLock.SqlServer\MultiLock.SqlServer.csproj" Type="Classic C#" />
-    <Project Path="src\Providers\MultiLock.ZooKeeper\MultiLock.ZooKeeper.csproj" Type="Classic C#" />
+    <Project Path="src\Providers\MultiLock.AzureBlobStorage\MultiLock.AzureBlobStorage.csproj" Type="C#" />
+    <Project Path="src\Providers\MultiLock.Consul\MultiLock.Consul.csproj" Type="C#" />
+    <Project Path="src\Providers\MultiLock.FileSystem\MultiLock.FileSystem.csproj" Type="C#" />
+    <Project Path="src\Providers\MultiLock.InMemory\MultiLock.InMemory.csproj" Type="C#" />
+    <Project Path="src\Providers\MultiLock.PostgreSQL\MultiLock.PostgreSQL.csproj" Type="C#" />
+    <Project Path="src\Providers\MultiLock.Redis\MultiLock.Redis.csproj" Type="C#" />
+    <Project Path="src\Providers\MultiLock.SqlServer\MultiLock.SqlServer.csproj" Type="C#" />
+    <Project Path="src\Providers\MultiLock.ZooKeeper\MultiLock.ZooKeeper.csproj" Type="C#" />
   </Folder>
   <Folder Name="/Samples/">
-    <Project Path="samples\MultiLock.MultiProvider\MultiLock.MultiProvider.csproj" Type="Classic C#" />
-    <Project Path="samples\MultiLock.Sample\MultiLock.Sample.csproj" Type="Classic C#" />
+    <Project Path="samples/MultiLock.SemaphoreSample/MultiLock.SemaphoreSample.csproj" />
+    <Project Path="samples\MultiLock.MultiProvider\MultiLock.MultiProvider.csproj" Type="C#" />
+    <Project Path="samples\MultiLock.Sample\MultiLock.Sample.csproj" Type="C#" />
   </Folder>
+  <Folder Name="/src/" />
+  <Folder Name="/src/Providers/" />
   <Folder Name="/Tests/">
-    <Project Path="tests\MultiLock.IntegrationTests\MultiLock.IntegrationTests.csproj" Type="Classic C#" />
-    <Project Path="tests\MultiLock.Tests\MultiLock.Tests.csproj" Type="Classic C#" />
+    <Project Path="tests\MultiLock.IntegrationTests\MultiLock.IntegrationTests.csproj" Type="C#" />
+    <Project Path="tests\MultiLock.Tests\MultiLock.Tests.csproj" Type="C#" />
   </Folder>
   <Folder Name="/_Files/">
     <File Path="tests\docker-compose.yml" />

--- a/MultiLock.slnx
+++ b/MultiLock.slnx
@@ -10,7 +10,7 @@
     <Project Path="src\Providers\MultiLock.ZooKeeper\MultiLock.ZooKeeper.csproj" Type="C#" />
   </Folder>
   <Folder Name="/Samples/">
-    <Project Path="samples/MultiLock.SemaphoreSample/MultiLock.SemaphoreSample.csproj" />
+    <Project Path="samples\MultiLock.SemaphoreSample\MultiLock.SemaphoreSample.csproj" Type="C#" />
     <Project Path="samples\MultiLock.MultiProvider\MultiLock.MultiProvider.csproj" Type="C#" />
     <Project Path="samples\MultiLock.Sample\MultiLock.Sample.csproj" Type="C#" />
   </Folder>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![NuGet - Consul](https://img.shields.io/nuget/v/MultiLock.Consul.svg?label=Consul)](https://www.nuget.org/packages/MultiLock.Consul/)
 [![NuGet - ZooKeeper](https://img.shields.io/nuget/v/MultiLock.ZooKeeper.svg?label=ZooKeeper)](https://www.nuget.org/packages/MultiLock.ZooKeeper/)
 
-A comprehensive .NET framework for implementing the Leader Election pattern with support for multiple providers including Azure Blob Storage, SQL Server, Redis, File System, In-Memory, Consul, and ZooKeeper.
+A comprehensive .NET framework for implementing **Leader Election** and **Distributed Semaphores** patterns with support for multiple providers including Azure Blob Storage, SQL Server, PostgreSQL, Redis, File System, In-Memory, Consul, and ZooKeeper.
 
 ## Requirements
 
@@ -37,32 +37,25 @@ A comprehensive .NET framework for implementing the Leader Election pattern with
 ┌────────────────────────────────────────────────────────────────────────────┐
 │                           CORE FRAMEWORK                                   │
 │                                                                            │
-│    ┌──────────────────────────────────────────────────────────────┐        │
-│    │         ILeaderElectionService (Interface)                   │        │
-│    │  • StartAsync() / StopAsync()                                │        │
-│    │  • IsLeader / GetCurrentLeaderAsync()                        │        │
-│    │  • GetLeadershipChangesAsync()                               │        │
-│    └────────────────────────┬─────────────────────────────────────┘        │
-│                             │                                              │
-│                             ▼                                              │
-│    ┌──────────────────────────────────────────────────────────────┐        │
-│    │         LeaderElectionService (Implementation)               │        │
-│    │  • Election Logic                                            │        │
-│    │  • Heartbeat Monitoring                                      │        │
-│    │  • Event Publishing                                          │        │
-│    └────────────────────────┬─────────────────────────────────────┘        │
-│                             │                                              │
-│                             ▼                                              │
-│    ┌──────────────────────────────────────────────────────────────┐        │
-│    │      ILeaderElectionProvider (Interface)                     │        │
-│    │  • TryAcquireLeadershipAsync()                               │        │
-│    │  • ReleaseLeadershipAsync()                                  │        │
-│    │  • UpdateHeartbeatAsync()                                    │        │
-│    └────────────────────────┬─────────────────────────────────────┘        │
-│                             │                                              │
-└─────────────────────────────┼──────────────────────────────────────────────┘
-                              │
-                              ▼
+│  ┌─────────────────────────────────┐  ┌─────────────────────────────────┐  │
+│  │  ILeaderElectionService         │  │  ISemaphoreService              │  │
+│  │  • StartAsync() / StopAsync()   │  │  • AcquireAsync()               │  │
+│  │  • IsLeader                     │  │  • TryAcquireAsync()            │  │
+│  │  • GetLeadershipChangesAsync()  │  │  • GetStatusChangesAsync()      │  │
+│  └───────────────┬─────────────────┘  └───────────────┬─────────────────┘  │
+│                  │                                    │                    │
+│                  ▼                                    ▼                    │
+│  ┌─────────────────────────────────┐  ┌─────────────────────────────────┐  │
+│  │  ILeaderElectionProvider        │  │  ISemaphoreProvider             │  │
+│  │  • TryAcquireLeadershipAsync()  │  │  • TryAcquireAsync()            │  │
+│  │  • ReleaseLeadershipAsync()     │  │  • ReleaseAsync()               │  │
+│  │  • UpdateHeartbeatAsync()       │  │  • UpdateHeartbeatAsync()       │  │
+│  └───────────────┬─────────────────┘  └───────────────┬─────────────────┘  │
+│                  │                                    │                    │
+└──────────────────┼────────────────────────────────────┼────────────────────┘
+                   │                                    │
+                   └────────────────┬───────────────────┘
+                                    ▼
 ┌────────────────────────────────────────────────────────────────────────────┐
 │                            PROVIDERS                                       │
 │                                                                            │
@@ -82,8 +75,9 @@ A comprehensive .NET framework for implementing the Leader Election pattern with
 ## Features
 
 - **Multiple Providers**: Support for various storage backends
-- **Distributed Mutex**: First-to-acquire becomes leader strategy
-- **Heartbeat Monitoring**: Automatic leader health monitoring and failover
+- **Leader Election**: First-to-acquire becomes leader strategy with automatic failover
+- **Distributed Semaphores**: Control concurrent access with configurable slot limits
+- **Heartbeat Monitoring**: Automatic health monitoring and failover
 - **Resilient Design**: Handles transient and persistent failures gracefully
 - **Thread-Safe**: All operations are thread-safe
 - **Configurable**: Extensive configuration options for timeouts, retry policies, etc.
@@ -601,6 +595,181 @@ Use `GetLeadershipChangesAsync()` to subscribe to these events and optionally fi
 - **ElectionInterval**: How often followers attempt to become leader
 - **LockTimeout**: Maximum time to hold a lock during election
 - **AutoStart**: Whether to automatically start the election process
+
+## Distributed Semaphores
+
+Distributed semaphores allow you to control concurrent access to a shared resource across multiple instances. Unlike leader election (which allows only one holder), semaphores allow a configurable number of concurrent holders.
+
+### Use Cases
+
+- **Rate Limiting**: Limit concurrent API calls to an external service
+- **Resource Pooling**: Control access to a limited pool of resources (database connections, licenses, etc.)
+- **Throttling**: Limit concurrent processing of expensive operations
+- **Capacity Management**: Ensure only N instances process work simultaneously
+
+### Quick Start
+
+```csharp
+using MultiLock;
+using MultiLock.InMemory;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add semaphore with In-Memory provider (max 5 concurrent holders)
+builder.Services.AddSemaphore<InMemorySemaphoreProvider>(options =>
+{
+    options.SemaphoreName = "api-rate-limiter";
+    options.MaxCount = 5;
+    options.HeartbeatInterval = TimeSpan.FromSeconds(30);
+    options.HeartbeatTimeout = TimeSpan.FromSeconds(90);
+});
+
+var app = builder.Build();
+```
+
+### Using the Semaphore Service
+
+```csharp
+public class RateLimitedApiClient
+{
+    private readonly ISemaphoreService _semaphore;
+    private readonly HttpClient _httpClient;
+
+    public RateLimitedApiClient(ISemaphoreService semaphore, HttpClient httpClient)
+    {
+        _semaphore = semaphore;
+        _httpClient = httpClient;
+    }
+
+    public async Task<string> CallExternalApiAsync(CancellationToken cancellationToken)
+    {
+        // Block until a slot is available (or cancellationToken is triggered)
+        await _semaphore.WaitForSlotAsync(cancellationToken);
+
+        try
+        {
+            // We now hold a slot - make the API call
+            return await _httpClient.GetStringAsync("/api/data", cancellationToken);
+        }
+        finally
+        {
+            // Always release the slot, even if the call throws
+            await _semaphore.ReleaseAsync(cancellationToken);
+        }
+    }
+
+    public async Task<string?> TryCallExternalApiAsync(CancellationToken cancellationToken)
+    {
+        // Try to acquire without blocking; returns false if all slots are taken
+        bool acquired = await _semaphore.TryAcquireAsync(cancellationToken);
+
+        if (!acquired)
+            return null;
+
+        try
+        {
+            return await _httpClient.GetStringAsync("/api/data", cancellationToken);
+        }
+        finally
+        {
+            await _semaphore.ReleaseAsync(cancellationToken);
+        }
+    }
+}
+```
+
+### Monitoring Semaphore Status
+
+```csharp
+// Check current status synchronously via the property
+SemaphoreStatus status = semaphore.CurrentStatus;
+Console.WriteLine($"Holding: {status.IsHolding}");
+Console.WriteLine($"Available: {status.AvailableSlots}/{status.MaxCount}");
+
+// Or fetch the latest state including all holders asynchronously
+SemaphoreInfo? info = await semaphore.GetSemaphoreInfoAsync(cancellationToken);
+if (info != null)
+    Console.WriteLine($"[Async] Active holders: {info.CurrentCount}/{info.MaxCount}");
+
+// Subscribe to status changes
+await foreach (var change in semaphore.GetStatusChangesAsync(cancellationToken))
+{
+    if (change.AcquiredSlot)
+    {
+        Console.WriteLine("Acquired a semaphore slot!");
+    }
+    else if (change.LostSlot)
+    {
+        Console.WriteLine("Lost semaphore slot!");
+    }
+}
+```
+
+### Provider-Specific Configuration
+
+All providers support semaphores with the same API:
+
+```csharp
+// PostgreSQL
+builder.Services.AddPostgreSqlSemaphore(
+    connectionString: "Host=localhost;Database=MyApp;...",
+    options => { options.SemaphoreName = "my-semaphore"; options.MaxCount = 10; });
+
+// Redis
+builder.Services.AddRedisSemaphore(
+    connectionString: "localhost:6379",
+    options => { options.SemaphoreName = "my-semaphore"; options.MaxCount = 10; });
+
+// SQL Server
+builder.Services.AddSqlServerSemaphore(
+    connectionString: "Server=localhost;Database=MyApp;...",
+    options => { options.SemaphoreName = "my-semaphore"; options.MaxCount = 10; });
+
+// Azure Blob Storage
+builder.Services.AddAzureBlobStorageSemaphore(
+    connectionString: "DefaultEndpointsProtocol=https;...",
+    options => { options.SemaphoreName = "my-semaphore"; options.MaxCount = 10; });
+
+// Consul
+builder.Services.AddConsulSemaphore(
+    address: "http://localhost:8500",
+    options => { options.SemaphoreName = "my-semaphore"; options.MaxCount = 10; });
+
+// ZooKeeper
+builder.Services.AddZooKeeperSemaphore(
+    connectionString: "localhost:2181",
+    options => { options.SemaphoreName = "my-semaphore"; options.MaxCount = 10; });
+
+// File System
+builder.Services.AddFileSystemSemaphore(
+    directoryPath: "/var/locks",
+    options => { options.SemaphoreName = "my-semaphore"; options.MaxCount = 10; });
+```
+
+### Semaphore Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `SemaphoreName` | Unique name for the semaphore | Required |
+| `MaxCount` | Maximum concurrent holders | Required |
+| `HolderId` | Unique identifier for this holder | Auto-generated |
+| `HeartbeatInterval` | How often to send heartbeats | 10 seconds |
+| `HeartbeatTimeout` | Time before a holder is considered dead | 30 seconds |
+| `AcquisitionInterval` | How often to retry acquiring a slot | 5 seconds |
+| `MaxRetryAttempts` | Retry attempts for transient failures | 3 |
+| `RetryBaseDelay` | Base delay between retries | 100ms |
+| `RetryMaxDelay` | Maximum delay between retries | 5 seconds |
+| `AutoStart` | Start acquiring on service start | true |
+| `EnableDetailedLogging` | Enable verbose logging | false |
+
+### Semaphore vs Leader Election
+
+| Feature | Leader Election | Semaphore |
+|---------|-----------------|-----------|
+| Concurrent holders | 1 (exclusive) | N (configurable) |
+| Use case | Single leader tasks | Rate limiting, pooling |
+| Failover | Automatic re-election | Slot becomes available |
+| API | `IsLeader` property | `IsHolding` property |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -675,6 +675,18 @@ public class RateLimitedApiClient
             await _semaphore.ReleaseAsync(cancellationToken);
         }
     }
+
+    public async Task<string?> CallWithScopeAsync(CancellationToken cancellationToken)
+    {
+        // AcquireScopeAsync returns a disposable scope when a slot is acquired (null if full),
+        // so the slot is released automatically at the end of the using block - no try/finally.
+        await using SemaphoreAcquisition? scope = await _semaphore.AcquireScopeAsync(cancellationToken);
+
+        if (scope is null)
+            return null;
+
+        return await _httpClient.GetStringAsync("/api/data", cancellationToken);
+    }
 }
 ```
 

--- a/samples/MultiLock.SemaphoreSample/MultiLock.SemaphoreSample.csproj
+++ b/samples/MultiLock.SemaphoreSample/MultiLock.SemaphoreSample.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MultiLock\MultiLock.csproj" />
+    <ProjectReference Include="..\..\src\Providers\MultiLock.InMemory\MultiLock.InMemory.csproj" />
+    <ProjectReference Include="..\..\src\Providers\MultiLock.FileSystem\MultiLock.FileSystem.csproj" />
+    <ProjectReference Include="..\..\src\Providers\MultiLock.Redis\MultiLock.Redis.csproj" />
+    <ProjectReference Include="..\..\src\Providers\MultiLock.SqlServer\MultiLock.SqlServer.csproj" />
+    <ProjectReference Include="..\..\src\Providers\MultiLock.PostgreSQL\MultiLock.PostgreSQL.csproj" />
+    <ProjectReference Include="..\..\src\Providers\MultiLock.AzureBlobStorage\MultiLock.AzureBlobStorage.csproj" />
+    <ProjectReference Include="..\..\src\Providers\MultiLock.Consul\MultiLock.Consul.csproj" />
+    <ProjectReference Include="..\..\src\Providers\MultiLock.ZooKeeper\MultiLock.ZooKeeper.csproj" />
+  </ItemGroup>
+
+</Project>
+

--- a/samples/MultiLock.SemaphoreSample/Program.cs
+++ b/samples/MultiLock.SemaphoreSample/Program.cs
@@ -1,0 +1,113 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MultiLock;
+using MultiLock.AzureBlobStorage;
+using MultiLock.Consul;
+using MultiLock.FileSystem;
+using MultiLock.InMemory;
+using MultiLock.PostgreSQL;
+using MultiLock.Redis;
+using MultiLock.SemaphoreSample;
+using MultiLock.SqlServer;
+using MultiLock.ZooKeeper;
+
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+// Configure logging
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole();
+builder.Logging.SetMinimumLevel(LogLevel.Information);
+
+// Choose provider based on command line argument
+string providerType = args.Length > 0 ? args[0].ToLowerInvariant() : "inmemory";
+int maxConcurrent = args.Length > 1 && int.TryParse(args[1], out int max) && max > 0 ? max : 3;
+
+Action<SemaphoreOptions> configureSemaphore = options =>
+{
+    options.SemaphoreName = "rate-limiter";
+    options.MaxCount = maxConcurrent;
+    options.HeartbeatInterval = TimeSpan.FromSeconds(10);
+    options.HeartbeatTimeout = TimeSpan.FromSeconds(30);
+    options.EnableDetailedLogging = true;
+};
+
+switch (providerType)
+{
+    case "inmemory":
+        builder.Services.AddInMemorySemaphore(configureSemaphore);
+        break;
+
+    case "filesystem":
+        builder.Services.AddFileSystemSemaphore(
+            Path.Combine(Path.GetTempPath(), "SemaphoreSample"),
+            configureSemaphore);
+        break;
+
+    case "sqlserver":
+        string sqlConnectionString = args.Length > 2 ? args[2] :
+            "Server=localhost;Database=SemaphoreSample;Trusted_Connection=true;TrustServerCertificate=true;";
+        builder.Services.AddSqlServerSemaphore(sqlConnectionString, configureSemaphore);
+        break;
+
+    case "azureblob":
+        string storageConnectionString = args.Length > 2 ? args[2] : "UseDevelopmentStorage=true";
+        builder.Services.AddAzureBlobStorageSemaphore(storageConnectionString, configureSemaphore);
+        break;
+
+    case "redis":
+        string redisConnectionString = args.Length > 2 ? args[2] : "localhost:6379";
+        builder.Services.AddRedisSemaphore(redisConnectionString, configureSemaphore);
+        break;
+
+    case "consul":
+        string consulAddress = args.Length > 2 ? args[2] : "http://localhost:8500";
+        builder.Services.AddConsulSemaphore(consulAddress, configureSemaphore);
+        break;
+
+    case "postgresql":
+        string postgresConnectionString = args.Length > 2 ? args[2] :
+            "Host=localhost;Database=semaphore;Username=postgres;Password=YOUR_PASSWORD_HERE";
+        builder.Services.AddPostgreSqlSemaphore(postgresConnectionString, configureSemaphore);
+        break;
+
+    case "zookeeper":
+        string zookeeperConnectionString = args.Length > 2 ? args[2] : "localhost:2181";
+        builder.Services.AddZooKeeperSemaphore(zookeeperConnectionString, configureSemaphore);
+        break;
+
+    default:
+        Console.WriteLine("Distributed Semaphore Sample - Rate Limiting Demo");
+        Console.WriteLine();
+        Console.WriteLine("Available providers:");
+        Console.WriteLine("  inmemory    - In-memory provider (default)");
+        Console.WriteLine("  filesystem  - File system provider");
+        Console.WriteLine("  sqlserver   - SQL Server provider");
+        Console.WriteLine("  postgresql  - PostgreSQL provider");
+        Console.WriteLine("  azureblob   - Azure Blob Storage provider");
+        Console.WriteLine("  redis       - Redis provider");
+        Console.WriteLine("  consul      - Consul provider");
+        Console.WriteLine("  zookeeper   - ZooKeeper provider");
+        Console.WriteLine();
+        Console.WriteLine("Usage: dotnet run [provider] [max_concurrent] [connection_string]");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  dotnet run inmemory 5");
+        Console.WriteLine("  dotnet run redis 3 localhost:6379");
+        Console.WriteLine("  dotnet run postgresql 5 \"Host=localhost;Database=test;...\"");
+        return;
+}
+
+// Add the sample background service that simulates rate-limited work
+builder.Services.AddHostedService<RateLimitedWorkerService>();
+
+IHost host = builder.Build();
+
+Console.WriteLine($"Starting Semaphore Sample with {providerType} provider (max {maxConcurrent} concurrent)...");
+Console.WriteLine("This demo simulates rate-limited API calls using distributed semaphores.");
+Console.WriteLine("Press Ctrl+C to exit");
+Console.WriteLine();
+
+await host.RunAsync();
+
+

--- a/samples/MultiLock.SemaphoreSample/RateLimitedWorkerService.cs
+++ b/samples/MultiLock.SemaphoreSample/RateLimitedWorkerService.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MultiLock.SemaphoreSample;
+
+/// <summary>
+/// Background service that demonstrates rate-limited work using distributed semaphores.
+/// Simulates multiple concurrent API calls that are throttled by the semaphore.
+/// </summary>
+public sealed class RateLimitedWorkerService : BackgroundService
+{
+    private readonly ISemaphoreService semaphoreService;
+    private readonly ILogger<RateLimitedWorkerService> logger;
+    private int requestCounter;
+
+    public RateLimitedWorkerService(
+        ISemaphoreService semaphoreService,
+        ILogger<RateLimitedWorkerService> logger)
+    {
+        this.semaphoreService = semaphoreService;
+        this.logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Wait for the service to start
+        await Task.Delay(1000, stoppingToken);
+
+        logger.LogInformation(
+            "Worker started. Semaphore: {SemaphoreName}, Max concurrent: {MaxCount}",
+            semaphoreService.SemaphoreName,
+            semaphoreService.MaxCount);
+
+        // Start monitoring semaphore status changes in background
+        _ = MonitorStatusChangesAsync(stoppingToken);
+
+        // Simulate continuous work requests
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            int requestId = Interlocked.Increment(ref requestCounter);
+
+            // Try to acquire a semaphore slot
+            logger.LogInformation("[Request {RequestId}] Attempting to acquire semaphore slot...", requestId);
+
+            bool acquired = await semaphoreService.TryAcquireAsync(stoppingToken);
+
+            if (acquired)
+            {
+                logger.LogInformation(
+                    "[Request {RequestId}] ✓ Acquired slot! Currently holding: {IsHolding}",
+                    requestId,
+                    semaphoreService.IsHolding);
+
+                // Simulate API call work
+                await SimulateApiCallAsync(requestId, stoppingToken);
+
+                // Release the slot
+                await semaphoreService.ReleaseAsync(stoppingToken);
+                logger.LogInformation("[Request {RequestId}] Released slot", requestId);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "[Request {RequestId}] ✗ Could not acquire slot (semaphore full)",
+                    requestId);
+            }
+
+            // Wait before next request
+            await Task.Delay(Random.Shared.Next(500, 2000), stoppingToken);
+        }
+    }
+
+    private async Task SimulateApiCallAsync(int requestId, CancellationToken cancellationToken)
+    {
+        // Simulate variable API call duration
+        int duration = Random.Shared.Next(1000, 5000);
+        logger.LogInformation(
+            "[Request {RequestId}] Processing API call (will take {Duration}ms)...",
+            requestId,
+            duration);
+
+        await Task.Delay(duration, cancellationToken);
+
+        logger.LogInformation("[Request {RequestId}] API call completed successfully", requestId);
+    }
+
+    private async Task MonitorStatusChangesAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (SemaphoreChangedEventArgs change in
+                semaphoreService.GetStatusChangesAsync(cancellationToken))
+            {
+                if (change.AcquiredSlot)
+                {
+                    logger.LogInformation(
+                        "📈 Status: Acquired slot (now holding, {Available}/{Max} available)",
+                        change.CurrentStatus.AvailableSlots,
+                        change.CurrentStatus.MaxCount);
+                }
+                else if (change.LostSlot)
+                {
+                    logger.LogInformation(
+                        "📉 Status: Lost slot (no longer holding, {Available}/{Max} available)",
+                        change.CurrentStatus.AvailableSlots,
+                        change.CurrentStatus.MaxCount);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when stopping
+        }
+    }
+}
+

--- a/src/MultiLock/Exceptions/SemaphoreException.cs
+++ b/src/MultiLock/Exceptions/SemaphoreException.cs
@@ -1,0 +1,33 @@
+﻿namespace MultiLock.Exceptions;
+
+/// <summary>
+/// The base exception for all distributed semaphore related errors.
+/// </summary>
+public class SemaphoreException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreException"/> class.
+    /// </summary>
+    public SemaphoreException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public SemaphoreException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public SemaphoreException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+

--- a/src/MultiLock/Exceptions/SemaphoreFullException.cs
+++ b/src/MultiLock/Exceptions/SemaphoreFullException.cs
@@ -1,0 +1,48 @@
+﻿namespace MultiLock.Exceptions;
+
+/// <summary>
+/// Exception thrown when a semaphore is at full capacity and cannot accept more holders.
+/// </summary>
+public class SemaphoreFullException : SemaphoreException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreFullException"/> class.
+    /// </summary>
+    public SemaphoreFullException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreFullException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public SemaphoreFullException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreFullException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public SemaphoreFullException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the semaphore that is full.
+    /// </summary>
+    public string? SemaphoreName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the maximum count of the semaphore.
+    /// </summary>
+    public int? MaxCount { get; init; }
+
+    /// <summary>
+    /// Gets or sets the current count of holders.
+    /// </summary>
+    public int? CurrentCount { get; init; }
+}
+

--- a/src/MultiLock/Exceptions/SemaphoreProviderException.cs
+++ b/src/MultiLock/Exceptions/SemaphoreProviderException.cs
@@ -1,0 +1,33 @@
+﻿namespace MultiLock.Exceptions;
+
+/// <summary>
+/// Exception thrown when a semaphore provider encounters an error.
+/// </summary>
+public class SemaphoreProviderException : SemaphoreException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreProviderException"/> class.
+    /// </summary>
+    public SemaphoreProviderException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreProviderException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public SemaphoreProviderException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreProviderException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public SemaphoreProviderException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+

--- a/src/MultiLock/Exceptions/SemaphoreTimeoutException.cs
+++ b/src/MultiLock/Exceptions/SemaphoreTimeoutException.cs
@@ -1,0 +1,43 @@
+﻿namespace MultiLock.Exceptions;
+
+/// <summary>
+/// Exception thrown when a semaphore operation times out.
+/// </summary>
+public class SemaphoreTimeoutException : SemaphoreException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreTimeoutException"/> class.
+    /// </summary>
+    public SemaphoreTimeoutException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreTimeoutException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public SemaphoreTimeoutException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreTimeoutException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public SemaphoreTimeoutException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the timeout duration that was exceeded.
+    /// </summary>
+    public TimeSpan? Timeout { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the semaphore that timed out.
+    /// </summary>
+    public string? SemaphoreName { get; init; }
+}
+

--- a/src/MultiLock/ISemaphoreProvider.cs
+++ b/src/MultiLock/ISemaphoreProvider.cs
@@ -1,0 +1,93 @@
+﻿namespace MultiLock;
+
+/// <summary>
+/// Defines the contract for distributed semaphore providers.
+/// A distributed semaphore allows a limited number of concurrent holders across multiple processes or machines.
+/// </summary>
+public interface ISemaphoreProvider : IDisposable
+{
+    /// <summary>
+    /// Attempts to acquire a slot in the semaphore.
+    /// </summary>
+    /// <param name="semaphoreName">The name of the semaphore.</param>
+    /// <param name="holderId">The unique identifier of the holder attempting to acquire.</param>
+    /// <param name="maxCount">The maximum number of concurrent holders allowed.</param>
+    /// <param name="metadata">Optional metadata associated with this holder.</param>
+    /// <param name="slotTimeout">The duration after which the slot expires if not renewed.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if the slot was acquired; otherwise, false.</returns>
+    Task<bool> TryAcquireAsync(
+        string semaphoreName,
+        string holderId,
+        int maxCount,
+        IReadOnlyDictionary<string, string> metadata,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Releases a slot held by the specified holder.
+    /// </summary>
+    /// <param name="semaphoreName">The name of the semaphore.</param>
+    /// <param name="holderId">The unique identifier of the holder releasing the slot.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task ReleaseAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the heartbeat for a held slot to prevent expiration.
+    /// </summary>
+    /// <param name="semaphoreName">The name of the semaphore.</param>
+    /// <param name="holderId">The unique identifier of the holder.</param>
+    /// <param name="metadata">Updated metadata for the holder.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if the heartbeat was updated; false if the holder does not hold a slot.</returns>
+    Task<bool> UpdateHeartbeatAsync(
+        string semaphoreName,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the current number of active (non-expired) holders for the semaphore.
+    /// </summary>
+    /// <param name="semaphoreName">The name of the semaphore.</param>
+    /// <param name="slotTimeout">The duration after which a holder is considered expired if not renewed.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The current number of active holders.</returns>
+    Task<int> GetCurrentCountAsync(
+        string semaphoreName,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets information about all current holders of the semaphore.
+    /// </summary>
+    /// <param name="semaphoreName">The name of the semaphore.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A collection of holder information, or an empty collection if no holders exist.</returns>
+    Task<IReadOnlyList<SemaphoreHolder>> GetHoldersAsync(
+        string semaphoreName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if the specified holder currently holds a slot in the semaphore.
+    /// </summary>
+    /// <param name="semaphoreName">The name of the semaphore.</param>
+    /// <param name="holderId">The unique identifier of the holder to check.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if the holder currently holds a slot; otherwise, false.</returns>
+    Task<bool> IsHoldingAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Performs a health check on the provider.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if the provider is healthy; otherwise, false.</returns>
+    Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default);
+}
+

--- a/src/MultiLock/ISemaphoreService.cs
+++ b/src/MultiLock/ISemaphoreService.cs
@@ -1,0 +1,88 @@
+﻿namespace MultiLock;
+
+/// <summary>
+/// Defines the contract for a high-level distributed semaphore service.
+/// Provides automatic heartbeat renewal, retry logic, and lifecycle management.
+/// </summary>
+public interface ISemaphoreService : IAsyncDisposable
+{
+    /// <summary>
+    /// Gets the current status of this participant in the semaphore.
+    /// </summary>
+    SemaphoreStatus CurrentStatus { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this participant currently holds a slot.
+    /// </summary>
+    bool IsHolding { get; }
+
+    /// <summary>
+    /// Gets the unique identifier of this participant.
+    /// </summary>
+    string HolderId { get; }
+
+    /// <summary>
+    /// Gets the name of the semaphore.
+    /// </summary>
+    string SemaphoreName { get; }
+
+    /// <summary>
+    /// Gets the maximum number of concurrent holders allowed.
+    /// </summary>
+    int MaxCount { get; }
+
+    /// <summary>
+    /// Starts the semaphore service.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task StartAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops the semaphore service and releases any held slot.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task StopAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempts to acquire a slot in the semaphore.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if a slot was acquired; otherwise, false.</returns>
+    Task<bool> TryAcquireAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Releases the currently held slot, if any.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task ReleaseAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Waits until a slot is acquired or the operation is cancelled.
+    /// </summary>
+    /// <param name="timeout">The maximum time to wait for a slot.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if a slot was acquired; false if the timeout expired.</returns>
+    Task<bool> WaitForSlotAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Waits until a slot is acquired or the operation is cancelled.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that completes when a slot is acquired.</returns>
+    Task WaitForSlotAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets information about the current state of the semaphore.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>Information about the semaphore, or null if unavailable.</returns>
+    Task<SemaphoreInfo?> GetSemaphoreInfoAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets an async enumerable of semaphore status changes.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the enumeration.</param>
+    /// <returns>An async enumerable of status change events.</returns>
+    IAsyncEnumerable<SemaphoreChangedEventArgs> GetStatusChangesAsync(CancellationToken cancellationToken = default);
+}
+

--- a/src/MultiLock/ISemaphoreService.cs
+++ b/src/MultiLock/ISemaphoreService.cs
@@ -57,6 +57,16 @@ public interface ISemaphoreService : IAsyncDisposable
     Task ReleaseAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Attempts to acquire a slot and, on success, returns a disposable scope that releases the
+    /// slot when disposed. Enables a scoped <c>await using</c> "acquire, do work, release" pattern.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="SemaphoreAcquisition"/> if a slot was acquired; otherwise <c>null</c>.
+    /// </returns>
+    Task<SemaphoreAcquisition?> AcquireScopeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Waits until a slot is acquired or the operation is cancelled.
     /// </summary>
     /// <param name="timeout">The maximum time to wait for a slot.</param>

--- a/src/MultiLock/MultiLock.csproj
+++ b/src/MultiLock/MultiLock.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <PackageId>MultiLock</PackageId>
-    <Description>A comprehensive .NET framework for implementing the Leader Election pattern with support for multiple providers including Azure Blob Storage, SQL Server, PostgreSQL, Redis, File System, In-Memory, Consul, and ZooKeeper.</Description>
-    <PackageTags>leader-election;distributed-systems;high-availability;failover;azure;redis;sql-server;postgresql;consul;zookeeper</PackageTags>
+    <Description>A comprehensive .NET framework for implementing Leader Election and Distributed Semaphores patterns with support for multiple providers including Azure Blob Storage, SQL Server, PostgreSQL, Redis, File System, In-Memory, Consul, and ZooKeeper.</Description>
+    <PackageTags>leader-election;distributed-systems;high-availability;failover;semaphore;rate-limiting;azure;redis;sql-server;postgresql;consul;zookeeper</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MultiLock/ParameterValidation.cs
+++ b/src/MultiLock/ParameterValidation.cs
@@ -3,11 +3,12 @@ using System.Text.RegularExpressions;
 namespace MultiLock;
 
 /// <summary>
-/// Provides validation methods for common parameters used across the leader election framework.
+/// Provides validation methods for common parameters used across the leader election and semaphore frameworks.
 /// </summary>
 public static partial class ParameterValidation
 {
     private const int maxIdentifierLength = 255;
+    private const int maxSqlIdentifierLength = 128;
     private const int maxMetadataKeyLength = 255;
     private const int maxMetadataValueLength = 4000;
     private const int maxMetadataCount = 100;
@@ -96,6 +97,100 @@ public static partial class ParameterValidation
     }
 
     /// <summary>
+    /// Validates a semaphore name parameter.
+    /// </summary>
+    /// <param name="semaphoreName">The semaphore name to validate.</param>
+    /// <param name="paramName">The parameter name for error messages.</param>
+    /// <exception cref="ArgumentException">Thrown when the semaphore name is invalid.</exception>
+    public static void ValidateSemaphoreName(string semaphoreName, string paramName = "semaphoreName")
+    {
+        if (string.IsNullOrWhiteSpace(semaphoreName))
+            throw new ArgumentException("Semaphore name cannot be null, empty, or whitespace.", paramName);
+
+        if (semaphoreName.Length > maxIdentifierLength)
+            throw new ArgumentException($"Semaphore name cannot exceed {maxIdentifierLength} characters.", paramName);
+
+        if (!IsValidIdentifier(semaphoreName))
+            throw new ArgumentException(
+                "Semaphore name contains invalid characters. Only alphanumeric characters, underscores, hyphens, and periods are allowed.",
+                paramName);
+    }
+
+    /// <summary>
+    /// Validates a holder ID parameter.
+    /// </summary>
+    /// <param name="holderId">The holder ID to validate.</param>
+    /// <param name="paramName">The parameter name for error messages.</param>
+    /// <exception cref="ArgumentException">Thrown when the holder ID is invalid.</exception>
+    public static void ValidateHolderId(string holderId, string paramName = "holderId")
+    {
+        if (string.IsNullOrWhiteSpace(holderId))
+            throw new ArgumentException("Holder ID cannot be null, empty, or whitespace.", paramName);
+
+        if (holderId.Length > maxIdentifierLength)
+            throw new ArgumentException($"Holder ID cannot exceed {maxIdentifierLength} characters.", paramName);
+
+        if (!IsValidIdentifier(holderId))
+            throw new ArgumentException(
+                "Holder ID contains invalid characters. Only alphanumeric characters, underscores, hyphens, and periods are allowed.",
+                paramName);
+    }
+
+    /// <summary>
+    /// Validates a max count parameter for semaphores.
+    /// </summary>
+    /// <param name="maxCount">The max count to validate.</param>
+    /// <param name="paramName">The parameter name for error messages.</param>
+    /// <exception cref="ArgumentException">Thrown when the max count is invalid.</exception>
+    public static void ValidateMaxCount(int maxCount, string paramName = "maxCount")
+    {
+        if (maxCount < 1)
+            throw new ArgumentException("Max count must be at least 1.", paramName);
+
+        if (maxCount > 10000)
+            throw new ArgumentException("Max count cannot exceed 10000.", paramName);
+    }
+
+    /// <summary>
+    /// Validates a slot timeout parameter.
+    /// </summary>
+    /// <param name="slotTimeout">The slot timeout to validate.</param>
+    /// <param name="paramName">The parameter name for error messages.</param>
+    /// <exception cref="ArgumentException">Thrown when the slot timeout is invalid.</exception>
+    public static void ValidateSlotTimeout(TimeSpan slotTimeout, string paramName = "slotTimeout")
+    {
+        if (slotTimeout <= TimeSpan.Zero)
+            throw new ArgumentException("Slot timeout must be positive.", paramName);
+
+        if (slotTimeout > TimeSpan.FromDays(1))
+            throw new ArgumentException("Slot timeout cannot exceed 1 day.", paramName);
+    }
+
+    /// <summary>
+    /// Validates that a string is a safe SQL identifier (schema or table name) that can be
+    /// interpolated directly into a SQL statement without quoting injection risk.
+    /// Only letters, digits, and underscores are permitted; the name must start with a letter or underscore.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="paramName">The parameter name for error messages.</param>
+    /// <exception cref="ArgumentException">Thrown when the value is not a safe SQL identifier.</exception>
+    public static void ValidateSqlIdentifier(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("SQL identifier cannot be null, empty, or whitespace.", paramName);
+
+        if (value.Length > maxSqlIdentifierLength)
+            throw new ArgumentException(
+                $"SQL identifier cannot exceed {maxSqlIdentifierLength} characters.", paramName);
+
+        if (!IsSafeSqlIdentifier(value))
+            throw new ArgumentException(
+                "SQL identifier contains invalid characters. " +
+                "Only letters, digits, and underscores are allowed, and the name must start with a letter or underscore.",
+                paramName);
+    }
+
+    /// <summary>
     /// Checks if a string is a valid identifier (alphanumeric, underscore, hyphen, period).
     /// </summary>
     /// <param name="value">The value to check.</param>
@@ -105,7 +200,15 @@ public static partial class ParameterValidation
         return IdentifierRegex().IsMatch(value);
     }
 
+    private static bool IsSafeSqlIdentifier(string value)
+    {
+        return SqlIdentifierRegex().IsMatch(value);
+    }
+
     [GeneratedRegex(@"^[a-zA-Z0-9_\-\.]+$", RegexOptions.Compiled)]
     private static partial Regex IdentifierRegex();
+
+    [GeneratedRegex(@"^[a-zA-Z_][a-zA-Z0-9_]*$", RegexOptions.Compiled)]
+    private static partial Regex SqlIdentifierRegex();
 }
 

--- a/src/MultiLock/ParameterValidation.cs
+++ b/src/MultiLock/ParameterValidation.cs
@@ -8,7 +8,12 @@ namespace MultiLock;
 public static partial class ParameterValidation
 {
     private const int maxIdentifierLength = 255;
-    private const int maxSqlIdentifierLength = 128;
+
+    /// <summary>
+    /// Default maximum SQL identifier length (SQL Server's limit). Providers with shorter limits
+    /// (e.g. PostgreSQL's 63) should pass their own value to <see cref="ValidateSqlIdentifier"/>.
+    /// </summary>
+    public const int DefaultSqlIdentifierMaxLength = 128;
     private const int maxMetadataKeyLength = 255;
     private const int maxMetadataValueLength = 4000;
     private const int maxMetadataCount = 100;
@@ -173,15 +178,20 @@ public static partial class ParameterValidation
     /// </summary>
     /// <param name="value">The value to validate.</param>
     /// <param name="paramName">The parameter name for error messages.</param>
+    /// <param name="maxLength">
+    /// The maximum permitted identifier length. Defaults to <see cref="DefaultSqlIdentifierMaxLength"/>
+    /// (SQL Server). Callers should pass the limit for their backend (e.g. 63 for PostgreSQL) so that
+    /// distinct long names cannot collide after server-side truncation.
+    /// </param>
     /// <exception cref="ArgumentException">Thrown when the value is not a safe SQL identifier.</exception>
-    public static void ValidateSqlIdentifier(string value, string paramName)
+    public static void ValidateSqlIdentifier(string value, string paramName, int maxLength = DefaultSqlIdentifierMaxLength)
     {
         if (string.IsNullOrWhiteSpace(value))
             throw new ArgumentException("SQL identifier cannot be null, empty, or whitespace.", paramName);
 
-        if (value.Length > maxSqlIdentifierLength)
+        if (value.Length > maxLength)
             throw new ArgumentException(
-                $"SQL identifier cannot exceed {maxSqlIdentifierLength} characters.", paramName);
+                $"SQL identifier cannot exceed {maxLength} characters.", paramName);
 
         if (!IsSafeSqlIdentifier(value))
             throw new ArgumentException(

--- a/src/MultiLock/SemaphoreAcquisition.cs
+++ b/src/MultiLock/SemaphoreAcquisition.cs
@@ -1,0 +1,86 @@
+﻿namespace MultiLock;
+
+/// <summary>
+/// Represents an acquired semaphore slot that can be disposed to release the slot.
+/// </summary>
+public sealed class SemaphoreAcquisition : IAsyncDisposable, IDisposable
+{
+    private readonly ISemaphoreProvider provider;
+    private readonly string semaphoreName;
+    private volatile bool isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreAcquisition"/> class.
+    /// </summary>
+    /// <param name="provider">The semaphore provider.</param>
+    /// <param name="semaphoreName">The name of the semaphore.</param>
+    /// <param name="holderId">The holder ID.</param>
+    /// <param name="acquiredAt">The time the slot was acquired.</param>
+    /// <param name="metadata">The metadata associated with the holder.</param>
+    public SemaphoreAcquisition(
+        ISemaphoreProvider provider,
+        string semaphoreName,
+        string holderId,
+        DateTimeOffset acquiredAt,
+        IReadOnlyDictionary<string, string> metadata)
+    {
+        this.provider = provider;
+        this.semaphoreName = semaphoreName;
+        HolderId = holderId;
+        AcquiredAt = acquiredAt;
+        Metadata = metadata;
+    }
+
+    /// <summary>
+    /// Gets the unique identifier of the holder.
+    /// </summary>
+    public string HolderId { get; }
+
+    /// <summary>
+    /// Gets the time when the slot was acquired.
+    /// </summary>
+    public DateTimeOffset AcquiredAt { get; }
+
+    /// <summary>
+    /// Gets the metadata associated with the holder.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the acquisition has been disposed.
+    /// </summary>
+    public bool IsDisposed => isDisposed;
+
+    /// <summary>
+    /// Releases the semaphore slot asynchronously.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (isDisposed)
+            return;
+
+        isDisposed = true;
+
+        try
+        {
+            await provider.ReleaseAsync(semaphoreName, HolderId);
+        }
+        catch
+        {
+            // Swallow exceptions during disposal to prevent masking other exceptions
+        }
+    }
+
+    /// <summary>
+    /// Releases the semaphore slot synchronously.
+    /// </summary>
+    /// <remarks>
+    /// Prefer <see cref="DisposeAsync"/> in async contexts. This synchronous path blocks the
+    /// calling thread and should not be used when a synchronization context is active.
+    /// </remarks>
+    public void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+}
+

--- a/src/MultiLock/SemaphoreAcquisition.cs
+++ b/src/MultiLock/SemaphoreAcquisition.cs
@@ -1,34 +1,67 @@
-﻿namespace MultiLock;
+using Microsoft.Extensions.Logging;
+
+namespace MultiLock;
 
 /// <summary>
-/// Represents an acquired semaphore slot that can be disposed to release the slot.
+/// Represents an acquired semaphore slot that releases the slot when disposed.
 /// </summary>
+/// <remarks>
+/// Obtain an instance from <see cref="ISemaphoreService.AcquireScopeAsync"/> for a scoped
+/// "acquire, do work, release on dispose" pattern, or construct one directly over an
+/// <see cref="ISemaphoreProvider"/> for low-level use.
+/// </remarks>
 public sealed class SemaphoreAcquisition : IAsyncDisposable, IDisposable
 {
-    private readonly ISemaphoreProvider provider;
-    private readonly string semaphoreName;
+    private readonly Func<ValueTask> releaseAsync;
+    private readonly ILogger? logger;
     private volatile bool isDisposed;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="SemaphoreAcquisition"/> class.
+    /// Initializes a new instance of the <see cref="SemaphoreAcquisition"/> class that releases
+    /// directly through the supplied provider.
     /// </summary>
     /// <param name="provider">The semaphore provider.</param>
     /// <param name="semaphoreName">The name of the semaphore.</param>
     /// <param name="holderId">The holder ID.</param>
     /// <param name="acquiredAt">The time the slot was acquired.</param>
     /// <param name="metadata">The metadata associated with the holder.</param>
+    /// <param name="logger">An optional logger used to report release failures during disposal.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider"/> or <paramref name="metadata"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="semaphoreName"/> or <paramref name="holderId"/> is null or whitespace.</exception>
     public SemaphoreAcquisition(
         ISemaphoreProvider provider,
         string semaphoreName,
         string holderId,
         DateTimeOffset acquiredAt,
-        IReadOnlyDictionary<string, string> metadata)
+        IReadOnlyDictionary<string, string> metadata,
+        ILogger? logger = null)
     {
-        this.provider = provider;
-        this.semaphoreName = semaphoreName;
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(semaphoreName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(holderId);
+        ArgumentNullException.ThrowIfNull(metadata);
+
         HolderId = holderId;
         AcquiredAt = acquiredAt;
         Metadata = metadata;
+        this.logger = logger;
+        releaseAsync = () => new ValueTask(provider.ReleaseAsync(semaphoreName, holderId));
+    }
+
+    // Internal constructor used by SemaphoreService so that disposing the scope releases through
+    // the service (stopping the heartbeat and updating status), not directly through the provider.
+    internal SemaphoreAcquisition(
+        string holderId,
+        DateTimeOffset acquiredAt,
+        IReadOnlyDictionary<string, string> metadata,
+        Func<ValueTask> releaseAsync,
+        ILogger? logger)
+    {
+        HolderId = holderId;
+        AcquiredAt = acquiredAt;
+        Metadata = metadata;
+        this.releaseAsync = releaseAsync;
+        this.logger = logger;
     }
 
     /// <summary>
@@ -63,11 +96,14 @@ public sealed class SemaphoreAcquisition : IAsyncDisposable, IDisposable
 
         try
         {
-            await provider.ReleaseAsync(semaphoreName, HolderId);
+            await releaseAsync();
         }
-        catch
+        catch (Exception ex)
         {
-            // Swallow exceptions during disposal to prevent masking other exceptions
+            // Never throw from disposal (it would mask other exceptions), but do not fail silently:
+            // a release failure means the slot lingers until its heartbeat expires, which is worth
+            // surfacing in logs.
+            logger?.LogWarning(ex, "Failed to release semaphore slot for holder {HolderId} during disposal", HolderId);
         }
     }
 
@@ -83,4 +119,3 @@ public sealed class SemaphoreAcquisition : IAsyncDisposable, IDisposable
         DisposeAsync().AsTask().GetAwaiter().GetResult();
     }
 }
-

--- a/src/MultiLock/SemaphoreChangedEventArgs.cs
+++ b/src/MultiLock/SemaphoreChangedEventArgs.cs
@@ -1,0 +1,27 @@
+﻿namespace MultiLock;
+
+/// <summary>
+/// Provides data for semaphore status change events.
+/// </summary>
+/// <param name="PreviousStatus">The previous semaphore status.</param>
+/// <param name="CurrentStatus">The current semaphore status.</param>
+public sealed record SemaphoreChangedEventArgs(
+    SemaphoreStatus PreviousStatus,
+    SemaphoreStatus CurrentStatus)
+{
+    /// <summary>
+    /// Gets a value indicating whether the participant acquired a slot in this change.
+    /// </summary>
+    public bool AcquiredSlot => !PreviousStatus.IsHolding && CurrentStatus.IsHolding;
+
+    /// <summary>
+    /// Gets a value indicating whether the participant lost their slot in this change.
+    /// </summary>
+    public bool LostSlot => PreviousStatus.IsHolding && !CurrentStatus.IsHolding;
+
+    /// <summary>
+    /// Gets a value indicating whether the holding status changed.
+    /// </summary>
+    public bool HoldingStatusChanged => PreviousStatus.IsHolding != CurrentStatus.IsHolding;
+}
+

--- a/src/MultiLock/SemaphoreHolder.cs
+++ b/src/MultiLock/SemaphoreHolder.cs
@@ -1,0 +1,26 @@
+﻿namespace MultiLock;
+
+/// <summary>
+/// Represents information about a holder of a semaphore slot.
+/// </summary>
+/// <param name="HolderId">The unique identifier of the holder.</param>
+/// <param name="AcquiredAt">The time when the slot was acquired.</param>
+/// <param name="LastHeartbeat">The time of the last heartbeat update.</param>
+/// <param name="Metadata">Optional metadata associated with the holder.</param>
+public sealed record SemaphoreHolder(
+    string HolderId,
+    DateTimeOffset AcquiredAt,
+    DateTimeOffset LastHeartbeat,
+    IReadOnlyDictionary<string, string> Metadata)
+{
+    /// <summary>
+    /// Determines whether the holder's slot is still healthy based on the specified timeout.
+    /// </summary>
+    /// <param name="timeout">The timeout duration after which a slot is considered unhealthy.</param>
+    /// <returns>True if the slot is healthy; otherwise, false.</returns>
+    public bool IsHealthy(TimeSpan timeout)
+    {
+        return DateTimeOffset.UtcNow - LastHeartbeat < timeout;
+    }
+}
+

--- a/src/MultiLock/SemaphoreInfo.cs
+++ b/src/MultiLock/SemaphoreInfo.cs
@@ -1,0 +1,31 @@
+﻿namespace MultiLock;
+
+/// <summary>
+/// Represents information about a distributed semaphore.
+/// </summary>
+/// <param name="SemaphoreName">The name of the semaphore.</param>
+/// <param name="MaxCount">The maximum number of concurrent holders allowed.</param>
+/// <param name="CurrentCount">The current number of active holders.</param>
+/// <param name="Holders">The list of current holders.</param>
+public sealed record SemaphoreInfo(
+    string SemaphoreName,
+    int MaxCount,
+    int CurrentCount,
+    IReadOnlyList<SemaphoreHolder> Holders)
+{
+    /// <summary>
+    /// Gets the number of available slots in the semaphore.
+    /// </summary>
+    public int AvailableSlots => Math.Max(0, MaxCount - CurrentCount);
+
+    /// <summary>
+    /// Gets a value indicating whether the semaphore has available slots.
+    /// </summary>
+    public bool HasAvailableSlots => AvailableSlots > 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the semaphore is at full capacity.
+    /// </summary>
+    public bool IsFull => CurrentCount >= MaxCount;
+}
+

--- a/src/MultiLock/SemaphoreOptions.cs
+++ b/src/MultiLock/SemaphoreOptions.cs
@@ -1,0 +1,116 @@
+﻿namespace MultiLock;
+
+/// <summary>
+/// Configuration options for the distributed semaphore service.
+/// </summary>
+public sealed class SemaphoreOptions
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for this participant.
+    /// If not specified, a GUID will be generated.
+    /// </summary>
+    public string? HolderId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the semaphore.
+    /// This identifies the shared resource being coordinated.
+    /// </summary>
+    public string SemaphoreName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent holders allowed.
+    /// Default is 1 (equivalent to a distributed lock).
+    /// </summary>
+    public int MaxCount { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the interval between heartbeat updates.
+    /// Default is 10 seconds.
+    /// </summary>
+    public TimeSpan HeartbeatInterval { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets or sets the timeout after which a slot is considered expired if no heartbeat is received.
+    /// Default is 30 seconds.
+    /// </summary>
+    public TimeSpan HeartbeatTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets the interval between acquisition attempts when waiting for a slot.
+    /// Default is 5 seconds.
+    /// </summary>
+    public TimeSpan AcquisitionInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets or sets the maximum number of retry attempts for transient failures.
+    /// Default is 3.
+    /// </summary>
+    public int MaxRetryAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the base delay for exponential backoff retries.
+    /// Default is 100 milliseconds.
+    /// </summary>
+    public TimeSpan RetryBaseDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Gets or sets the maximum delay for exponential backoff retries.
+    /// Default is 5 seconds.
+    /// </summary>
+    public TimeSpan RetryMaxDelay { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets or sets optional metadata to associate with this holder.
+    /// </summary>
+    public Dictionary<string, string> Metadata { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically start acquisition attempts.
+    /// Default is true.
+    /// </summary>
+    public bool AutoStart { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable detailed logging.
+    /// Default is false.
+    /// </summary>
+    public bool EnableDetailedLogging { get; set; }
+
+    /// <summary>
+    /// Validates the options and throws if invalid.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when options are invalid.</exception>
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(SemaphoreName))
+            throw new ArgumentException("Semaphore name cannot be null or empty.", nameof(SemaphoreName));
+
+        if (MaxCount < 1)
+            throw new ArgumentException("Max count must be at least 1.", nameof(MaxCount));
+
+        if (HeartbeatInterval <= TimeSpan.Zero)
+            throw new ArgumentException("Heartbeat interval must be positive.", nameof(HeartbeatInterval));
+
+        if (HeartbeatTimeout <= TimeSpan.Zero)
+            throw new ArgumentException("Heartbeat timeout must be positive.", nameof(HeartbeatTimeout));
+
+        if (HeartbeatTimeout <= HeartbeatInterval)
+            throw new ArgumentException("Heartbeat timeout must be greater than heartbeat interval.", nameof(HeartbeatTimeout));
+
+        if (AcquisitionInterval <= TimeSpan.Zero)
+            throw new ArgumentException("Acquisition interval must be positive.", nameof(AcquisitionInterval));
+
+        if (MaxRetryAttempts < 0)
+            throw new ArgumentException("Max retry attempts cannot be negative.", nameof(MaxRetryAttempts));
+
+        if (RetryBaseDelay <= TimeSpan.Zero)
+            throw new ArgumentException("Retry base delay must be positive.", nameof(RetryBaseDelay));
+
+        if (RetryMaxDelay <= TimeSpan.Zero)
+            throw new ArgumentException("Retry max delay must be positive.", nameof(RetryMaxDelay));
+
+        if (RetryMaxDelay < RetryBaseDelay)
+            throw new ArgumentException("Retry max delay must be greater than or equal to retry base delay.", nameof(RetryMaxDelay));
+    }
+}
+

--- a/src/MultiLock/SemaphoreOptions.cs
+++ b/src/MultiLock/SemaphoreOptions.cs
@@ -82,11 +82,15 @@ public sealed class SemaphoreOptions
     /// <exception cref="ArgumentException">Thrown when options are invalid.</exception>
     public void Validate()
     {
-        if (string.IsNullOrWhiteSpace(SemaphoreName))
-            throw new ArgumentException("Semaphore name cannot be null or empty.", nameof(SemaphoreName));
+        // Reuse the shared validators so options validation stays consistent with the per-call
+        // validation performed by every provider (character rules, length limits, metadata bounds).
+        ParameterValidation.ValidateSemaphoreName(SemaphoreName, nameof(SemaphoreName));
+        ParameterValidation.ValidateMaxCount(MaxCount, nameof(MaxCount));
 
-        if (MaxCount < 1)
-            throw new ArgumentException("Max count must be at least 1.", nameof(MaxCount));
+        if (HolderId != null)
+            ParameterValidation.ValidateHolderId(HolderId, nameof(HolderId));
+
+        ParameterValidation.ValidateMetadata(Metadata, nameof(Metadata));
 
         if (HeartbeatInterval <= TimeSpan.Zero)
             throw new ArgumentException("Heartbeat interval must be positive.", nameof(HeartbeatInterval));

--- a/src/MultiLock/SemaphoreService.cs
+++ b/src/MultiLock/SemaphoreService.cs
@@ -1,0 +1,738 @@
+﻿using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace MultiLock;
+
+/// <summary>
+/// Implementation of the distributed semaphore service that manages slot acquisition and lifecycle.
+/// </summary>
+public sealed class SemaphoreService : BackgroundService, ISemaphoreService
+{
+    private readonly ISemaphoreProvider provider;
+    private readonly SemaphoreOptions options;
+    private readonly ILogger<SemaphoreService> logger;
+    private readonly SemaphoreSlim stateLock = new(1, 1);
+    private readonly CancellationTokenSource cancellationTokenSource = new();
+    private readonly Channel<SemaphoreChangedEventArgs> broadcastChannel;
+    private readonly List<Channel<SemaphoreChangedEventArgs>> subscriberChannels = [];
+    private readonly object subscriberLock = new();
+
+    private SemaphoreStatus currentStatus;
+    private Timer? heartbeatTimer;
+    private Timer? acquisitionTimer;
+    private readonly Task broadcastTask;
+    private volatile bool isDisposed;
+    private volatile int activeCallbacks;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemaphoreService"/> class.
+    /// </summary>
+    /// <param name="provider">The semaphore provider.</param>
+    /// <param name="options">The semaphore options.</param>
+    /// <param name="logger">The logger.</param>
+    public SemaphoreService(
+        ISemaphoreProvider provider,
+        IOptions<SemaphoreOptions> options,
+        ILogger<SemaphoreService> logger)
+    {
+        this.provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        this.options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        this.options.Validate();
+
+        HolderId = this.options.HolderId ?? Environment.MachineName + "-" + Guid.NewGuid().ToString("N")[..8];
+        currentStatus = SemaphoreStatus.Unknown(this.options.MaxCount);
+
+        var channelOptions = new UnboundedChannelOptions
+        {
+            SingleWriter = true,
+            SingleReader = true
+        };
+        broadcastChannel = Channel.CreateUnbounded<SemaphoreChangedEventArgs>(channelOptions);
+        broadcastTask = Task.Run(BroadcastEventsAsync);
+
+        this.logger.LogInformation(
+            "Semaphore service initialized for holder {HolderId} on semaphore {SemaphoreName} (max: {MaxCount})",
+            HolderId, this.options.SemaphoreName, this.options.MaxCount);
+    }
+
+    /// <inheritdoc />
+    public SemaphoreStatus CurrentStatus => currentStatus;
+
+    /// <inheritdoc />
+    public bool IsHolding => currentStatus.IsHolding;
+
+    /// <inheritdoc />
+    public string HolderId { get; }
+
+    /// <inheritdoc />
+    public string SemaphoreName => options.SemaphoreName;
+
+    /// <inheritdoc />
+    public int MaxCount => options.MaxCount;
+
+    // BackgroundService.ExecuteAsync is abstract and must be implemented, but acquisition is driven
+    // entirely through StartAsync so this method is never reached via the normal hosted-service path.
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public override async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        // When AutoStart is false the caller drives acquisition manually via TryAcquireAsync().
+        if (!options.AutoStart)
+            return;
+
+        await stateLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (heartbeatTimer != null || acquisitionTimer != null)
+                return;
+
+            logger.LogInformation("Starting semaphore service for holder {HolderId}", HolderId);
+            await StartAcquisitionProcessAsync(cancellationToken);
+        }
+        finally
+        {
+            stateLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public override async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (isDisposed)
+            return;
+
+        await stateLock.WaitAsync(cancellationToken);
+        try
+        {
+            logger.LogInformation("Stopping semaphore service for holder {HolderId}", HolderId);
+
+            if (currentStatus.IsHolding)
+            {
+                try
+                {
+                    await provider.ReleaseAsync(options.SemaphoreName, HolderId, cancellationToken);
+                    UpdateStatus(SemaphoreStatus.Waiting(Math.Max(0, currentStatus.CurrentCount - 1), options.MaxCount, null));
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to release slot during shutdown");
+                }
+            }
+
+            broadcastChannel.Writer.TryComplete();
+            await broadcastTask.WaitAsync(cancellationToken);
+            await cancellationTokenSource.CancelAsync();
+
+            await DisposeTimersAsync();
+        }
+        finally
+        {
+            stateLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAcquireAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        await stateLock.WaitAsync(cancellationToken);
+        try
+        {
+            return await TryAcquireInternalAsync(cancellationToken);
+        }
+        finally
+        {
+            stateLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        await stateLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!currentStatus.IsHolding)
+                return;
+
+            await ExecuteWithRetryAsync(
+                async ct => await provider.ReleaseAsync(options.SemaphoreName, HolderId, ct),
+                "release slot",
+                cancellationToken);
+
+            UpdateStatus(SemaphoreStatus.Waiting(Math.Max(0, currentStatus.CurrentCount - 1), options.MaxCount, null));
+
+            await DisposeHeartbeatTimerAsync();
+            StartAcquisitionTimer();
+        }
+        finally
+        {
+            stateLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task WaitForSlotAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        // Subscribe BEFORE checking IsHolding to close a TOCTOU window: IsHolding could
+        // transition true between our check and the subscription registration, causing us
+        // to miss the broadcast and wait indefinitely. GetStatusChangesAsyncCoreImpl
+        // registers the subscriber channel synchronously (inside a lock, before any yield),
+        // so by the time MoveNextAsync() suspends the subscription is already in place.
+        //
+        // A localCts is used so that when IsHolding is already true we can cancel the
+        // pending MoveNextAsync before the await-using disposes the enumerator. Without
+        // cancellation, DisposeAsync throws NotSupportedException because it cannot
+        // interrupt a ReadAllAsync awaiting an uncancellable token.
+        using var localCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var subscriptionRegistered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        IAsyncEnumerator<SemaphoreChangedEventArgs> enumerator =
+            GetStatusChangesAsyncCore(localCts.Token, subscriptionRegistered)
+                .GetAsyncEnumerator(CancellationToken.None);
+
+        await using (enumerator)
+        {
+            // Drive the state machine synchronously to the first suspension point, which
+            // registers the subscription and sets subscriptionRegistered before any await.
+            ValueTask<bool> pending = enumerator.MoveNextAsync();
+
+            // subscriptionRegistered is already complete — check IsHolding with the guarantee
+            // that any concurrent transition will be delivered to our subscriber channel.
+            if (currentStatus.IsHolding)
+            {
+                // Cancel the pending MoveNextAsync so DisposeAsync can interrupt ReadAllAsync.
+                localCts.Cancel();
+                try { await pending; } catch (OperationCanceledException) { }
+                return;
+            }
+
+            while (await pending)
+            {
+                if (enumerator.Current.AcquiredSlot)
+                    return;
+                pending = enumerator.MoveNextAsync();
+            }
+        }
+
+        // The enumerator completes normally only when the broadcast channel is closed (disposal).
+        // A cancelled token throws OperationCanceledException and never reaches here.
+        throw new ObjectDisposedException(nameof(SemaphoreService));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> WaitForSlotAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        // localCts combines the caller's token, the timeout, and the "already holding" early-exit.
+        using var localCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var subscriptionRegistered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Subscribe BEFORE checking IsHolding — see WaitForSlotAsync overload for rationale.
+        IAsyncEnumerator<SemaphoreChangedEventArgs> enumerator =
+            GetStatusChangesAsyncCore(localCts.Token, subscriptionRegistered)
+                .GetAsyncEnumerator(CancellationToken.None);
+
+        await using (enumerator)
+        {
+            ValueTask<bool> pending = enumerator.MoveNextAsync();
+
+            if (currentStatus.IsHolding)
+            {
+                localCts.Cancel();
+                try { await pending; } catch (OperationCanceledException) { }
+                return true;
+            }
+
+            try
+            {
+                while (await pending)
+                {
+                    if (enumerator.Current.AcquiredSlot)
+                        return true;
+                    pending = enumerator.MoveNextAsync();
+                }
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                return false;
+            }
+        }
+
+        // The enumerator completes normally only when the broadcast channel is closed (disposal).
+        throw new ObjectDisposedException(nameof(SemaphoreService));
+    }
+
+    /// <inheritdoc />
+    public async Task<SemaphoreInfo?> GetSemaphoreInfoAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        int currentCount = await provider.GetCurrentCountAsync(options.SemaphoreName, options.HeartbeatTimeout, cancellationToken);
+        IReadOnlyList<SemaphoreHolder> holders = await provider.GetHoldersAsync(options.SemaphoreName, cancellationToken);
+
+        return new SemaphoreInfo(options.SemaphoreName, options.MaxCount, currentCount, holders);
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<SemaphoreChangedEventArgs> GetStatusChangesAsync(CancellationToken cancellationToken = default)
+        => GetStatusChangesAsyncCore(cancellationToken, subscriberRegistered: null);
+
+    internal IAsyncEnumerable<SemaphoreChangedEventArgs> GetStatusChangesAsyncCore(
+        CancellationToken cancellationToken,
+        TaskCompletionSource? subscriberRegistered)
+    {
+        return GetStatusChangesAsyncCoreImpl(cancellationToken, subscriberRegistered);
+    }
+
+    private async IAsyncEnumerable<SemaphoreChangedEventArgs> GetStatusChangesAsyncCoreImpl(
+        [EnumeratorCancellation] CancellationToken cancellationToken,
+        TaskCompletionSource? subscriberRegistered)
+    {
+        ThrowIfDisposed();
+
+        var subscriberChannel = Channel.CreateUnbounded<SemaphoreChangedEventArgs>(new UnboundedChannelOptions
+        {
+            SingleWriter = true,
+            SingleReader = true
+        });
+
+        lock (subscriberLock)
+        {
+            subscriberChannels.Add(subscriberChannel);
+        }
+
+        subscriberRegistered?.TrySetResult();
+
+        try
+        {
+            await foreach (SemaphoreChangedEventArgs eventArgs in subscriberChannel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return eventArgs;
+            }
+        }
+        finally
+        {
+            lock (subscriberLock)
+            {
+                subscriberChannels.Remove(subscriberChannel);
+            }
+            subscriberChannel.Writer.TryComplete();
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Prefer <see cref="DisposeAsync"/> in async contexts. This synchronous path blocks the
+    /// calling thread and should not be used when a synchronization context is active.
+    /// </remarks>
+    public override void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+        base.Dispose();
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (isDisposed)
+            return;
+
+        isDisposed = true;
+        await cancellationTokenSource.CancelAsync();
+        await DisposeTimersAsync();
+
+        var waitStart = DateTime.UtcNow;
+        var maxWait = TimeSpan.FromSeconds(10);
+
+        while (activeCallbacks > 0 && DateTime.UtcNow - waitStart < maxWait)
+            await Task.Delay(10).ConfigureAwait(false);
+
+        if (activeCallbacks > 0)
+        {
+            logger.LogWarning(
+                "Disposing SemaphoreService with {ActiveCallbacks} active callbacks still running after {MaxWait}s timeout",
+                activeCallbacks, maxWait.TotalSeconds);
+        }
+
+        stateLock.Dispose();
+        cancellationTokenSource.Dispose();
+        broadcastChannel.Writer.TryComplete();
+
+        try
+        {
+            await broadcastTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when the service is cancelled during disposal.
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error draining broadcast task during disposal");
+        }
+
+        lock (subscriberLock)
+        {
+            foreach (Channel<SemaphoreChangedEventArgs> channel in subscriberChannels)
+                channel.Writer.TryComplete();
+            subscriberChannels.Clear();
+        }
+
+        try
+        {
+            provider.Dispose();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error disposing provider");
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+    }
+
+    private async Task StartAcquisitionProcessAsync(CancellationToken cancellationToken)
+    {
+        await TryAcquireInternalAsync(cancellationToken);
+
+        if (currentStatus.IsHolding)
+            StartHeartbeatTimer();
+        else
+            StartAcquisitionTimer();
+    }
+
+    private async Task<bool> TryAcquireInternalAsync(CancellationToken cancellationToken)
+    {
+        return await ExecuteWithRetryAsync(
+            async ct =>
+            {
+                bool acquired = await provider.TryAcquireAsync(
+                    options.SemaphoreName,
+                    HolderId,
+                    options.MaxCount,
+                    options.Metadata,
+                    options.HeartbeatTimeout,
+                    ct);
+
+                int currentCount = await provider.GetCurrentCountAsync(options.SemaphoreName, options.HeartbeatTimeout, ct);
+
+                if (acquired)
+                {
+                    UpdateStatus(SemaphoreStatus.Holding(currentCount, options.MaxCount));
+
+                    await DisposeAcquisitionTimerAsync();
+                    StartHeartbeatTimer();
+
+                    logger.LogInformation("Successfully acquired slot for holder {HolderId}", HolderId);
+                    return true;
+                }
+                else
+                {
+                    UpdateStatus(SemaphoreStatus.Waiting(currentCount, options.MaxCount, DateTimeOffset.UtcNow.Add(options.AcquisitionInterval)));
+
+                    logger.LogDebug("Failed to acquire slot for holder {HolderId}. Semaphore is full.", HolderId);
+                    return false;
+                }
+            },
+            "acquire slot",
+            cancellationToken);
+    }
+
+    private async Task<T> ExecuteWithRetryAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken)
+    {
+        int attempt = 0;
+        Exception? lastException = null;
+
+        while (attempt <= options.MaxRetryAttempts)
+        {
+            try
+            {
+                return await operation(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+                attempt++;
+
+                if (attempt > options.MaxRetryAttempts)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Failed to {OperationName} for holder {HolderId} after {Attempts} attempts",
+                        operationName, HolderId, attempt);
+                    break;
+                }
+
+                TimeSpan delay = CalculateBackoffDelay(attempt);
+
+                if (options.EnableDetailedLogging)
+                    logger.LogDebug(
+                        ex,
+                        "Attempt {Attempt} to {OperationName} for holder {HolderId} failed. Retrying in {Delay}ms",
+                        attempt, operationName, HolderId, delay.TotalMilliseconds);
+
+                await Task.Delay(delay, cancellationToken);
+            }
+        }
+
+        // All attempts exhausted — re-throw so callers can distinguish a provider error
+        // from a legitimate "not acquired / not holding" false return.
+        throw lastException!;
+    }
+
+    private async Task ExecuteWithRetryAsync(
+        Func<CancellationToken, Task> operation,
+        string operationName,
+        CancellationToken cancellationToken)
+    {
+        await ExecuteWithRetryAsync(
+            async ct =>
+            {
+                await operation(ct);
+                return true;
+            },
+            operationName,
+            cancellationToken);
+    }
+
+    private TimeSpan CalculateBackoffDelay(int attempt)
+    {
+        // Exponential backoff with jitter: baseDelay * 2^(attempt-1) + random jitter
+        double exponentialMs = options.RetryBaseDelay.TotalMilliseconds * Math.Pow(2, attempt - 1);
+        double jitterMs = Random.Shared.NextDouble() * options.RetryBaseDelay.TotalMilliseconds;
+        double totalMs = exponentialMs + jitterMs;
+
+        // Cap at max delay
+        double cappedMs = Math.Min(totalMs, options.RetryMaxDelay.TotalMilliseconds);
+
+        return TimeSpan.FromMilliseconds(cappedMs);
+    }
+
+    private void StartHeartbeatTimer()
+    {
+        heartbeatTimer?.Dispose();
+        heartbeatTimer = new Timer(
+            HeartbeatTimerCallback,
+            null,
+            options.HeartbeatInterval,
+            options.HeartbeatInterval);
+    }
+
+    private void StartAcquisitionTimer()
+    {
+        acquisitionTimer?.Dispose();
+        acquisitionTimer = new Timer(
+            AcquisitionTimerCallback,
+            null,
+            options.AcquisitionInterval,
+            options.AcquisitionInterval);
+    }
+
+    private async void HeartbeatTimerCallback(object? state)
+    {
+        if (isDisposed)
+            return;
+
+        Interlocked.Increment(ref activeCallbacks);
+        try
+        {
+            await HeartbeatCallbackAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unhandled exception in heartbeat timer callback for holder {HolderId}", HolderId);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref activeCallbacks);
+        }
+    }
+
+    private async void AcquisitionTimerCallback(object? state)
+    {
+        if (isDisposed)
+            return;
+
+        Interlocked.Increment(ref activeCallbacks);
+        try
+        {
+            await AcquisitionCallbackAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unhandled exception in acquisition timer callback for holder {HolderId}", HolderId);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref activeCallbacks);
+        }
+    }
+
+    private async Task HeartbeatCallbackAsync()
+    {
+        if (isDisposed || cancellationTokenSource.Token.IsCancellationRequested)
+            return;
+
+        try
+        {
+            await stateLock.WaitAsync(cancellationTokenSource.Token);
+            try
+            {
+                if (isDisposed)
+                    return;
+
+                if (!currentStatus.IsHolding)
+                    return;
+
+                bool heartbeatSuccessful = await ExecuteWithRetryAsync(
+                    async ct => await provider.UpdateHeartbeatAsync(
+                        options.SemaphoreName,
+                        HolderId,
+                        options.Metadata,
+                        ct),
+                    "update heartbeat",
+                    cancellationTokenSource.Token);
+
+                if (!heartbeatSuccessful)
+                {
+                    logger.LogWarning("Lost slot for holder {HolderId}", HolderId);
+
+                    int currentCount = await provider.GetCurrentCountAsync(options.SemaphoreName, options.HeartbeatTimeout, cancellationTokenSource.Token);
+                    UpdateStatus(SemaphoreStatus.Waiting(currentCount, options.MaxCount, DateTimeOffset.UtcNow.Add(options.AcquisitionInterval)));
+
+                    await DisposeHeartbeatTimerAsync();
+                    StartAcquisitionTimer();
+                }
+                else if (options.EnableDetailedLogging)
+                {
+                    logger.LogDebug("Heartbeat successful for holder {HolderId}", HolderId);
+                }
+            }
+            finally
+            {
+                stateLock.Release();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // Expected during disposal
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during cancellation
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error during heartbeat for holder {HolderId}", HolderId);
+        }
+    }
+
+    private async Task AcquisitionCallbackAsync()
+    {
+        if (isDisposed || cancellationTokenSource.Token.IsCancellationRequested)
+            return;
+
+        try
+        {
+            await stateLock.WaitAsync(cancellationTokenSource.Token);
+            try
+            {
+                if (isDisposed)
+                    return;
+
+                if (currentStatus.IsHolding)
+                    return;
+
+                await TryAcquireInternalAsync(cancellationTokenSource.Token);
+            }
+            finally
+            {
+                stateLock.Release();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // Expected during disposal
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during cancellation
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error during acquisition attempt for holder {HolderId}", HolderId);
+        }
+    }
+
+    private void UpdateStatus(SemaphoreStatus newStatus)
+    {
+        SemaphoreStatus previousStatus = currentStatus;
+        currentStatus = newStatus;
+
+        var eventArgs = new SemaphoreChangedEventArgs(previousStatus, newStatus);
+
+        if (!broadcastChannel.Writer.TryWrite(eventArgs))
+            logger.LogWarning("Failed to write semaphore change event to broadcast channel. Channel may be completed.");
+    }
+
+    private async Task BroadcastEventsAsync()
+    {
+        await foreach (SemaphoreChangedEventArgs eventArgs in broadcastChannel.Reader.ReadAllAsync().ConfigureAwait(false))
+        {
+            lock (subscriberLock)
+            {
+                foreach (Channel<SemaphoreChangedEventArgs> channel in subscriberChannels)
+                    channel.Writer.TryWrite(eventArgs);
+            }
+        }
+    }
+
+    private async Task DisposeTimersAsync()
+    {
+        await DisposeHeartbeatTimerAsync();
+        await DisposeAcquisitionTimerAsync();
+    }
+
+    private async Task DisposeHeartbeatTimerAsync()
+    {
+        if (heartbeatTimer != null)
+        {
+            await heartbeatTimer.DisposeAsync().ConfigureAwait(false);
+            heartbeatTimer = null;
+        }
+    }
+
+    private async Task DisposeAcquisitionTimerAsync()
+    {
+        if (acquisitionTimer != null)
+        {
+            await acquisitionTimer.DisposeAsync().ConfigureAwait(false);
+            acquisitionTimer = null;
+        }
+    }
+}

--- a/src/MultiLock/SemaphoreService.cs
+++ b/src/MultiLock/SemaphoreService.cs
@@ -183,6 +183,24 @@ public sealed class SemaphoreService : BackgroundService, ISemaphoreService
     }
 
     /// <inheritdoc />
+    public async Task<SemaphoreAcquisition?> AcquireScopeAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        if (!await TryAcquireAsync(cancellationToken))
+            return null;
+
+        // Release through the service (not the provider directly) so disposing the scope also stops
+        // the heartbeat timer and updates the published status, keeping lifecycle state consistent.
+        return new SemaphoreAcquisition(
+            HolderId,
+            DateTimeOffset.UtcNow,
+            options.Metadata,
+            () => new ValueTask(ReleaseAsync()),
+            logger);
+    }
+
+    /// <inheritdoc />
     public async Task WaitForSlotAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
@@ -421,6 +439,10 @@ public sealed class SemaphoreService : BackgroundService, ISemaphoreService
 
     private async Task<bool> TryAcquireInternalAsync(CancellationToken cancellationToken)
     {
+        // The acquire + count below are not a single atomic provider call, so ExecuteWithRetryAsync
+        // may re-run TryAcquireAsync after a transient failure of the count call. This is safe only
+        // because every provider treats a re-acquire by the same holderId as an idempotent renewal
+        // rather than a second slot; do not weaken that invariant in provider implementations.
         return await ExecuteWithRetryAsync(
             async ct =>
             {

--- a/src/MultiLock/SemaphoreService.cs
+++ b/src/MultiLock/SemaphoreService.cs
@@ -129,6 +129,17 @@ public sealed class SemaphoreService : BackgroundService, ISemaphoreService
 
             broadcastChannel.Writer.TryComplete();
             await broadcastTask.WaitAsync(cancellationToken);
+
+            // Complete the per-subscriber channels too. Waiters in WaitForSlotAsync /
+            // GetStatusChangesAsync block on their own channel, not on the broadcast reader, so
+            // completing only the broadcast channel would leave them hanging until DisposeAsync.
+            // Each enumerator removes itself from the list in its finally block once completed.
+            lock (subscriberLock)
+            {
+                foreach (Channel<SemaphoreChangedEventArgs> channel in subscriberChannels)
+                    channel.Writer.TryComplete();
+            }
+
             await cancellationTokenSource.CancelAsync();
 
             await DisposeTimersAsync();

--- a/src/MultiLock/SemaphoreServiceExtensions.cs
+++ b/src/MultiLock/SemaphoreServiceExtensions.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace MultiLock;
+
+/// <summary>
+/// Extension methods for configuring distributed semaphore services.
+/// </summary>
+public static class SemaphoreServiceExtensions
+{
+    /// <summary>
+    /// Adds distributed semaphore services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is null.</exception>
+    public static IServiceCollection AddSemaphore(
+        this IServiceCollection services,
+        Action<SemaphoreOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        if (configureOptions != null)
+            services.Configure(configureOptions);
+
+        services.TryAddSingleton<ISemaphoreService, SemaphoreService>();
+        services.AddHostedService<SemaphoreService>(provider =>
+            (SemaphoreService)provider.GetRequiredService<ISemaphoreService>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds distributed semaphore services with a specific provider to the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TProvider">The type of the semaphore provider.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is null.</exception>
+    public static IServiceCollection AddSemaphore<TProvider>(
+        this IServiceCollection services,
+        Action<SemaphoreOptions>? configureOptions = null)
+        where TProvider : class, ISemaphoreProvider
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<ISemaphoreProvider, TProvider>();
+        return services.AddSemaphore(configureOptions);
+    }
+
+    /// <summary>
+    /// Adds distributed semaphore services with a provider factory to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="providerFactory">A factory function to create the provider.</param>
+    /// <param name="configureOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="providerFactory"/> is null.</exception>
+    public static IServiceCollection AddSemaphore(
+        this IServiceCollection services,
+        Func<IServiceProvider, ISemaphoreProvider> providerFactory,
+        Action<SemaphoreOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(providerFactory);
+
+        services.TryAddSingleton(providerFactory);
+        return services.AddSemaphore(configureOptions);
+    }
+}
+

--- a/src/MultiLock/SemaphoreServiceExtensions.cs
+++ b/src/MultiLock/SemaphoreServiceExtensions.cs
@@ -15,6 +15,13 @@ public static class SemaphoreServiceExtensions
     /// <param name="configureOptions">An action to configure the semaphore options.</param>
     /// <returns>The service collection for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is null.</exception>
+    /// <remarks>
+    /// Registers <see cref="ISemaphoreService"/> as a single shared singleton (also surfaced as a
+    /// hosted service), so a container supports <b>one semaphore</b> — the one named by
+    /// <see cref="SemaphoreOptions.SemaphoreName"/>. To coordinate several distinct semaphores from
+    /// one application, use separate hosts/containers or resolve providers directly; there is no
+    /// keyed/named-semaphore registration.
+    /// </remarks>
     public static IServiceCollection AddSemaphore(
         this IServiceCollection services,
         Action<SemaphoreOptions>? configureOptions = null)

--- a/src/MultiLock/SemaphoreStatus.cs
+++ b/src/MultiLock/SemaphoreStatus.cs
@@ -1,0 +1,55 @@
+﻿namespace MultiLock;
+
+/// <summary>
+/// Represents the current status of a semaphore participant.
+/// </summary>
+/// <param name="IsHolding">Whether this participant currently holds a slot.</param>
+/// <param name="CurrentCount">The current number of holders in the semaphore.</param>
+/// <param name="MaxCount">The maximum number of concurrent holders allowed.</param>
+/// <param name="LastAcquisitionAttempt">The time of the last acquisition attempt.</param>
+/// <param name="NextAcquisitionAttempt">The scheduled time for the next acquisition attempt, if any.</param>
+public sealed record SemaphoreStatus(
+    bool IsHolding,
+    int CurrentCount,
+    int MaxCount,
+    DateTimeOffset? LastAcquisitionAttempt,
+    DateTimeOffset? NextAcquisitionAttempt)
+{
+    /// <summary>
+    /// Gets the number of available slots in the semaphore.
+    /// </summary>
+    public int AvailableSlots => Math.Max(0, MaxCount - CurrentCount);
+
+    /// <summary>
+    /// Gets a value indicating whether the semaphore has available slots.
+    /// </summary>
+    public bool HasAvailableSlots => AvailableSlots > 0;
+
+    /// <summary>
+    /// Creates a status indicating the participant is holding a slot.
+    /// </summary>
+    /// <param name="currentCount">The current number of holders.</param>
+    /// <param name="maxCount">The maximum number of holders.</param>
+    /// <returns>A new <see cref="SemaphoreStatus"/> instance.</returns>
+    public static SemaphoreStatus Holding(int currentCount, int maxCount) =>
+        new(true, currentCount, maxCount, DateTimeOffset.UtcNow, null);
+
+    /// <summary>
+    /// Creates a status indicating the participant is waiting for a slot.
+    /// </summary>
+    /// <param name="currentCount">The current number of holders.</param>
+    /// <param name="maxCount">The maximum number of holders.</param>
+    /// <param name="nextAttempt">The scheduled time for the next acquisition attempt.</param>
+    /// <returns>A new <see cref="SemaphoreStatus"/> instance.</returns>
+    public static SemaphoreStatus Waiting(int currentCount, int maxCount, DateTimeOffset? nextAttempt) =>
+        new(false, currentCount, maxCount, DateTimeOffset.UtcNow, nextAttempt);
+
+    /// <summary>
+    /// Creates a status indicating no semaphore information is available.
+    /// </summary>
+    /// <param name="maxCount">The maximum number of holders.</param>
+    /// <returns>A new <see cref="SemaphoreStatus"/> instance.</returns>
+    public static SemaphoreStatus Unknown(int maxCount) =>
+        new(false, 0, maxCount, null, null);
+}
+

--- a/src/MultiLock/SemaphoreStatus.cs
+++ b/src/MultiLock/SemaphoreStatus.cs
@@ -16,9 +16,17 @@ public sealed record SemaphoreStatus(
     DateTimeOffset? NextAcquisitionAttempt)
 {
     /// <summary>
-    /// Gets the number of available slots in the semaphore.
+    /// Gets a value indicating whether this status reflects an actual observation from the provider.
+    /// This is <c>false</c> only for the initial <see cref="Unknown"/> state, before the first
+    /// provider read. While unknown, availability is reported conservatively as none.
     /// </summary>
-    public int AvailableSlots => Math.Max(0, MaxCount - CurrentCount);
+    public bool HasInformation { get; init; } = true;
+
+    /// <summary>
+    /// Gets the number of available slots in the semaphore. Returns 0 while the status is
+    /// <see cref="Unknown"/> so callers don't act on unobserved capacity.
+    /// </summary>
+    public int AvailableSlots => HasInformation ? Math.Max(0, MaxCount - CurrentCount) : 0;
 
     /// <summary>
     /// Gets a value indicating whether the semaphore has available slots.
@@ -50,6 +58,6 @@ public sealed record SemaphoreStatus(
     /// <param name="maxCount">The maximum number of holders.</param>
     /// <returns>A new <see cref="SemaphoreStatus"/> instance.</returns>
     public static SemaphoreStatus Unknown(int maxCount) =>
-        new(false, 0, maxCount, null, null);
+        new(false, 0, maxCount, null, null) { HasInformation = false };
 }
 

--- a/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageSemaphoreOptions.cs
@@ -1,0 +1,47 @@
+﻿namespace MultiLock.AzureBlobStorage;
+
+/// <summary>
+/// Configuration options for the Azure Blob Storage semaphore provider.
+/// </summary>
+public sealed class AzureBlobStorageSemaphoreOptions
+{
+    /// <summary>
+    /// Gets or sets the Azure Storage connection string.
+    /// </summary>
+    public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the container used for semaphores.
+    /// Default is "semaphores".
+    /// </summary>
+    public string ContainerName { get; set; } = "semaphores";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically create the container if it doesn't exist.
+    /// Default is true.
+    /// </summary>
+    public bool AutoCreateContainer { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of retry attempts for optimistic concurrency conflicts.
+    /// Default is 5.
+    /// </summary>
+    public int MaxRetryAttempts { get; set; } = 5;
+
+    /// <summary>
+    /// Validates the configuration options.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when configuration is invalid.</exception>
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(ConnectionString))
+            throw new ArgumentException("Connection string cannot be null or empty.", nameof(ConnectionString));
+
+        if (string.IsNullOrWhiteSpace(ContainerName))
+            throw new ArgumentException("Container name cannot be null or empty.", nameof(ContainerName));
+
+        if (MaxRetryAttempts < 1)
+            throw new ArgumentException("Max retry attempts must be at least 1.", nameof(MaxRetryAttempts));
+    }
+}
+

--- a/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageSemaphoreOptions.cs
@@ -1,9 +1,11 @@
-﻿namespace MultiLock.AzureBlobStorage;
+﻿using System.Text.RegularExpressions;
+
+namespace MultiLock.AzureBlobStorage;
 
 /// <summary>
 /// Configuration options for the Azure Blob Storage semaphore provider.
 /// </summary>
-public sealed class AzureBlobStorageSemaphoreOptions
+public sealed partial class AzureBlobStorageSemaphoreOptions
 {
     /// <summary>
     /// Gets or sets the Azure Storage connection string.
@@ -40,8 +42,20 @@ public sealed class AzureBlobStorageSemaphoreOptions
         if (string.IsNullOrWhiteSpace(ContainerName))
             throw new ArgumentException("Container name cannot be null or empty.", nameof(ContainerName));
 
+        // Validate the container name against Azure's rules up front for a clearer error than the
+        // SDK's runtime failure: 3-63 chars, lowercase letters/digits/hyphens, must start and end
+        // with a letter or digit, and no consecutive hyphens.
+        if (ContainerName.Length is < 3 or > 63 || !ContainerNameRegex().IsMatch(ContainerName))
+            throw new ArgumentException(
+                "Container name must be 3-63 characters, contain only lowercase letters, digits, and hyphens, " +
+                "start and end with a letter or digit, and not contain consecutive hyphens.",
+                nameof(ContainerName));
+
         if (MaxRetryAttempts < 1)
             throw new ArgumentException("Max retry attempts must be at least 1.", nameof(MaxRetryAttempts));
     }
+
+    [GeneratedRegex("^[a-z0-9]+(-[a-z0-9]+)*$", RegexOptions.Compiled)]
+    private static partial Regex ContainerNameRegex();
 }
 

--- a/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageSemaphoreProvider.cs
@@ -1,0 +1,454 @@
+﻿using System.Text;
+using System.Text.Json;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.Exceptions;
+
+namespace MultiLock.AzureBlobStorage;
+
+/// <summary>
+/// Azure Blob Storage implementation of the semaphore provider.
+/// Uses a blob to store holder information with optimistic concurrency (ETags) for atomic updates.
+/// </summary>
+public sealed class AzureBlobStorageSemaphoreProvider : ISemaphoreProvider
+{
+    private readonly AzureBlobStorageSemaphoreOptions options;
+    private readonly ILogger<AzureBlobStorageSemaphoreProvider> logger;
+    private readonly BlobServiceClient blobServiceClient;
+    private readonly SemaphoreSlim initializationLock = new(1, 1);
+    private volatile bool isInitialized;
+    private volatile bool isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureBlobStorageSemaphoreProvider"/> class.
+    /// </summary>
+    /// <param name="options">The Azure Blob Storage options.</param>
+    /// <param name="logger">The logger.</param>
+    public AzureBlobStorageSemaphoreProvider(
+        IOptions<AzureBlobStorageSemaphoreOptions> options,
+        ILogger<AzureBlobStorageSemaphoreProvider> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+
+        this.options.Validate();
+
+        blobServiceClient = new BlobServiceClient(this.options.ConnectionString);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAcquireAsync(
+        string semaphoreName,
+        string holderId,
+        int maxCount,
+        IReadOnlyDictionary<string, string> metadata,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMaxCount(maxCount);
+        ParameterValidation.ValidateMetadata(metadata);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken);
+
+            for (int attempt = 0; attempt < options.MaxRetryAttempts; attempt++)
+            {
+                BlobClient blobClient = await GetBlobClientAsync(semaphoreName, cancellationToken);
+                (SemaphoreData data, ETag etag) = await ReadSemaphoreDataAsync(blobClient, cancellationToken);
+
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+                DateTimeOffset expiryTime = now.Subtract(slotTimeout);
+
+                // Remove expired holders
+                data.Holders.RemoveAll(h => h.LastHeartbeat < expiryTime);
+
+                // Check if holder already exists (renewal)
+                HolderData? existingHolder = data.Holders.Find(h => h.HolderId == holderId);
+                if (existingHolder != null)
+                {
+                    existingHolder.LastHeartbeat = now;
+                    existingHolder.Metadata = new Dictionary<string, string>(metadata);
+
+                    if (await TryWriteSemaphoreDataAsync(blobClient, data, etag, cancellationToken))
+                    {
+                        logger.LogInformation("Renewed slot for holder {HolderId} in semaphore {SemaphoreName}",
+                            holderId, semaphoreName);
+                        return true;
+                    }
+                    continue; // Retry on conflict
+                }
+
+                // Check if there's room
+                if (data.Holders.Count >= maxCount)
+                {
+                    logger.LogDebug("Failed to acquire slot for holder {HolderId} in semaphore {SemaphoreName} - full ({CurrentCount}/{MaxCount})",
+                        holderId, semaphoreName, data.Holders.Count, maxCount);
+                    return false;
+                }
+
+                // Add new holder
+                data.Holders.Add(new HolderData
+                {
+                    HolderId = holderId,
+                    AcquiredAt = now,
+                    LastHeartbeat = now,
+                    Metadata = new Dictionary<string, string>(metadata)
+                });
+
+                if (await TryWriteSemaphoreDataAsync(blobClient, data, etag, cancellationToken))
+                {
+                    logger.LogInformation("Acquired slot for holder {HolderId} in semaphore {SemaphoreName}",
+                        holderId, semaphoreName);
+                    return true;
+                }
+                // Retry on conflict
+            }
+
+            logger.LogWarning("Failed to acquire slot for holder {HolderId} in semaphore {SemaphoreName} after {MaxRetries} attempts",
+                holderId, semaphoreName, options.MaxRetryAttempts);
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to acquire semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken);
+
+            for (int attempt = 0; attempt < options.MaxRetryAttempts; attempt++)
+            {
+                BlobClient blobClient = await GetBlobClientAsync(semaphoreName, cancellationToken);
+                (SemaphoreData data, ETag etag) = await ReadSemaphoreDataAsync(blobClient, cancellationToken);
+
+                int removed = data.Holders.RemoveAll(h => h.HolderId == holderId);
+                if (removed == 0)
+                {
+                    logger.LogDebug("Holder {HolderId} not found in semaphore {SemaphoreName}", holderId, semaphoreName);
+                    return;
+                }
+
+                if (await TryWriteSemaphoreDataAsync(blobClient, data, etag, cancellationToken))
+                {
+                    logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}",
+                        holderId, semaphoreName);
+                    return;
+                }
+            }
+
+            logger.LogWarning("Failed to release slot for holder {HolderId} in semaphore {SemaphoreName} after {MaxRetries} attempts due to repeated ETag conflicts",
+                holderId, semaphoreName, options.MaxRetryAttempts);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to release semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateHeartbeatAsync(
+        string semaphoreName,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMetadata(metadata);
+
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken);
+
+            for (int attempt = 0; attempt < options.MaxRetryAttempts; attempt++)
+            {
+                BlobClient blobClient = await GetBlobClientAsync(semaphoreName, cancellationToken);
+                (SemaphoreData data, ETag etag) = await ReadSemaphoreDataAsync(blobClient, cancellationToken);
+
+                HolderData? holder = data.Holders.Find(h => h.HolderId == holderId);
+                if (holder == null)
+                {
+                    logger.LogWarning("Heartbeat update failed for holder {HolderId} in semaphore {SemaphoreName} - not a holder",
+                        holderId, semaphoreName);
+                    return false;
+                }
+
+                holder.LastHeartbeat = DateTimeOffset.UtcNow;
+                holder.Metadata = new Dictionary<string, string>(metadata);
+
+                if (await TryWriteSemaphoreDataAsync(blobClient, data, etag, cancellationToken))
+                {
+                    logger.LogDebug("Updated heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                        holderId, semaphoreName);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to update heartbeat", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetCurrentCountAsync(
+        string semaphoreName,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken);
+            BlobClient blobClient = await GetBlobClientAsync(semaphoreName, cancellationToken);
+            (SemaphoreData data, _) = await ReadSemaphoreDataAsync(blobClient, cancellationToken);
+            DateTimeOffset expiryTime = DateTimeOffset.UtcNow.Subtract(slotTimeout);
+            return data.Holders.Count(h => h.LastHeartbeat >= expiryTime);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting current count for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get current count", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SemaphoreHolder>> GetHoldersAsync(
+        string semaphoreName,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken);
+            BlobClient blobClient = await GetBlobClientAsync(semaphoreName, cancellationToken);
+            (SemaphoreData data, _) = await ReadSemaphoreDataAsync(blobClient, cancellationToken);
+
+            return data.Holders
+                .Select(h => new SemaphoreHolder(h.HolderId, h.AcquiredAt, h.LastHeartbeat, h.Metadata))
+                .ToList();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get holders", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsHoldingAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken);
+            BlobClient blobClient = await GetBlobClientAsync(semaphoreName, cancellationToken);
+            (SemaphoreData data, _) = await ReadSemaphoreDataAsync(blobClient, cancellationToken);
+            return data.Holders.Exists(h => h.HolderId == holderId);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error checking if holder {HolderId} is holding semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to check holding status", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
+    {
+        if (isDisposed)
+            return false;
+
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken);
+            BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(options.ContainerName);
+            await containerClient.GetPropertiesAsync(cancellationToken: cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Health check failed for Azure Blob Storage semaphore provider");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (isDisposed) return;
+        isDisposed = true;
+        initializationLock.Dispose();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (!isDisposed) return;
+        throw new ObjectDisposedException(nameof(AzureBlobStorageSemaphoreProvider));
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (isInitialized)
+            return;
+
+        await initializationLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (isInitialized)
+                return;
+
+            if (options.AutoCreateContainer)
+            {
+                BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(options.ContainerName);
+                await containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+                logger.LogInformation("Container {ContainerName} created or verified", options.ContainerName);
+            }
+
+            isInitialized = true;
+        }
+        finally
+        {
+            initializationLock.Release();
+        }
+    }
+
+    private async Task<BlobClient> GetBlobClientAsync(string semaphoreName, CancellationToken cancellationToken)
+    {
+        BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(options.ContainerName);
+        string blobName = $"{semaphoreName}.json";
+        BlobClient blobClient = containerClient.GetBlobClient(blobName);
+
+        if (await blobClient.ExistsAsync(cancellationToken)) return blobClient;
+
+        try
+        {
+            var emptyData = new SemaphoreData { Holders = [] };
+            string json = JsonSerializer.Serialize(emptyData);
+            byte[] content = Encoding.UTF8.GetBytes(json);
+            await blobClient.UploadAsync(new BinaryData(content), cancellationToken: cancellationToken);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 409)
+        {
+            // Blob was created by another instance, ignore
+        }
+
+        return blobClient;
+    }
+
+    private async Task<(SemaphoreData Data, ETag ETag)> ReadSemaphoreDataAsync(
+        BlobClient blobClient,
+        CancellationToken cancellationToken)
+    {
+        Response<BlobDownloadResult> response = await blobClient.DownloadContentAsync(cancellationToken: cancellationToken);
+        SemaphoreData? data = JsonSerializer.Deserialize<SemaphoreData>(response.Value.Content.ToString());
+        return (data ?? new SemaphoreData { Holders = [] }, response.Value.Details.ETag);
+    }
+
+    private async Task<bool> TryWriteSemaphoreDataAsync(
+        BlobClient blobClient,
+        SemaphoreData data,
+        ETag etag,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            string json = JsonSerializer.Serialize(data);
+            byte[] content = Encoding.UTF8.GetBytes(json);
+            var conditions = new BlobRequestConditions { IfMatch = etag };
+            await blobClient.UploadAsync(
+                new BinaryData(content),
+                new BlobUploadOptions { Conditions = conditions },
+                cancellationToken);
+            return true;
+        }
+        catch (RequestFailedException ex) when (ex.Status == 412)
+        {
+            // Precondition failed - ETag mismatch
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Internal class to represent semaphore data stored in blob.
+    /// </summary>
+    private sealed class SemaphoreData
+    {
+        public List<HolderData> Holders { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Internal class to represent holder data.
+    /// </summary>
+    private sealed class HolderData
+    {
+        public string HolderId { get; set; } = string.Empty;
+        public DateTimeOffset AcquiredAt { get; set; }
+        public DateTimeOffset LastHeartbeat { get; set; }
+        public Dictionary<string, string> Metadata { get; set; } = new();
+    }
+}

--- a/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageSemaphoreProvider.cs
@@ -83,7 +83,9 @@ public sealed class AzureBlobStorageSemaphoreProvider : ISemaphoreProvider
                             holderId, semaphoreName);
                         return true;
                     }
-                    continue; // Retry on conflict
+
+                    await DelayBeforeRetryAsync(attempt, cancellationToken); // Retry on conflict
+                    continue;
                 }
 
                 // Check if there's room
@@ -109,9 +111,12 @@ public sealed class AzureBlobStorageSemaphoreProvider : ISemaphoreProvider
                         holderId, semaphoreName);
                     return true;
                 }
-                // Retry on conflict
+
+                await DelayBeforeRetryAsync(attempt, cancellationToken); // Retry on conflict
             }
 
+            // Exhausting the retry budget under contention is not an error: report the slot as
+            // unacquired and let the caller retry on its normal acquisition interval.
             logger.LogWarning("Failed to acquire slot for holder {HolderId} in semaphore {SemaphoreName} after {MaxRetries} attempts",
                 holderId, semaphoreName, options.MaxRetryAttempts);
             return false;
@@ -160,16 +165,22 @@ public sealed class AzureBlobStorageSemaphoreProvider : ISemaphoreProvider
                         holderId, semaphoreName);
                     return;
                 }
+
+                await DelayBeforeRetryAsync(attempt, cancellationToken); // Retry on conflict
             }
 
-            logger.LogWarning("Failed to release slot for holder {HolderId} in semaphore {SemaphoreName} after {MaxRetries} attempts due to repeated ETag conflicts",
-                holderId, semaphoreName, options.MaxRetryAttempts);
+            // Unlike acquire, a failed release must not be swallowed: the slot would otherwise
+            // linger until its heartbeat times out, blocking other holders. Surface the failure so
+            // the caller (and the service's retry policy) can react.
+            throw new SemaphoreProviderException(
+                $"Failed to release semaphore slot for holder '{holderId}' in semaphore '{semaphoreName}' " +
+                $"after {options.MaxRetryAttempts} attempts due to repeated ETag conflicts.");
         }
         catch (OperationCanceledException)
         {
             throw;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not SemaphoreException)
         {
             logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
@@ -215,6 +226,8 @@ public sealed class AzureBlobStorageSemaphoreProvider : ISemaphoreProvider
                         holderId, semaphoreName);
                     return true;
                 }
+
+                await DelayBeforeRetryAsync(attempt, cancellationToken); // Retry on conflict
             }
 
             return false;
@@ -377,6 +390,17 @@ public sealed class AzureBlobStorageSemaphoreProvider : ISemaphoreProvider
         }
     }
 
+    // Exponential backoff with jitter between optimistic-concurrency (ETag) conflict retries.
+    // Without a delay, contending callers re-read and re-write in a tight loop, amplifying
+    // contention and burning the (small) retry budget against each other.
+    private static Task DelayBeforeRetryAsync(int attempt, CancellationToken cancellationToken)
+    {
+        double baseMs = 25 * Math.Pow(2, attempt);
+        double jitterMs = Random.Shared.NextDouble() * 25;
+        double cappedMs = Math.Min(baseMs + jitterMs, 1000);
+        return Task.Delay(TimeSpan.FromMilliseconds(cappedMs), cancellationToken);
+    }
+
     private async Task<BlobClient> GetBlobClientAsync(string semaphoreName, CancellationToken cancellationToken)
     {
         BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(options.ContainerName);
@@ -406,6 +430,9 @@ public sealed class AzureBlobStorageSemaphoreProvider : ISemaphoreProvider
     {
         Response<BlobDownloadResult> response = await blobClient.DownloadContentAsync(cancellationToken: cancellationToken);
         SemaphoreData? data = JsonSerializer.Deserialize<SemaphoreData>(response.Value.Content.ToString());
+        if (data == null)
+            logger.LogWarning("Semaphore blob {BlobName} contained content that could not be deserialized; treating it as empty",
+                blobClient.Name);
         return (data ?? new SemaphoreData { Holders = [] }, response.Value.Details.ETag);
     }
 

--- a/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageServiceCollectionExtensions.cs
+++ b/src/Providers/MultiLock.AzureBlobStorage/AzureBlobStorageServiceCollectionExtensions.cs
@@ -3,10 +3,11 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MultiLock.AzureBlobStorage;
 
 /// <summary>
-/// Extension methods for configuring Azure Blob Storage leader election services.
+/// Extension methods for configuring Azure Blob Storage leader election and semaphore services.
 /// </summary>
 public static class AzureBlobStorageServiceCollectionExtensions
 {
+    // Leader Election Methods
     /// <summary>
     /// Adds Azure Blob Storage leader election services to the dependency injection container.
     /// </summary>
@@ -65,5 +66,67 @@ public static class AzureBlobStorageServiceCollectionExtensions
                 options.ContainerName = containerName;
             },
             configureLeaderElectionOptions);
+    }
+
+    // Semaphore Methods
+
+    /// <summary>
+    /// Adds Azure Blob Storage semaphore services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the Azure Blob Storage options.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddAzureBlobStorageSemaphore(
+        this IServiceCollection services,
+        Action<AzureBlobStorageSemaphoreOptions> configureOptions,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        services.Configure(configureOptions);
+
+        if (configureSemaphoreOptions != null)
+            services.Configure(configureSemaphoreOptions);
+
+        return services.AddSemaphore<AzureBlobStorageSemaphoreProvider>();
+    }
+
+    /// <summary>
+    /// Adds Azure Blob Storage semaphore services to the dependency injection container with connection string.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The Azure Storage connection string.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddAzureBlobStorageSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddAzureBlobStorageSemaphore(
+            options => options.ConnectionString = connectionString,
+            configureSemaphoreOptions);
+    }
+
+    /// <summary>
+    /// Adds Azure Blob Storage semaphore services to the dependency injection container with connection string and container name.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The Azure Storage connection string.</param>
+    /// <param name="containerName">The container name for semaphore blobs.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddAzureBlobStorageSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        string containerName,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddAzureBlobStorageSemaphore(
+            options =>
+            {
+                options.ConnectionString = connectionString;
+                options.ContainerName = containerName;
+            },
+            configureSemaphoreOptions);
     }
 }

--- a/src/Providers/MultiLock.AzureBlobStorage/MultiLock.AzureBlobStorage.csproj
+++ b/src/Providers/MultiLock.AzureBlobStorage/MultiLock.AzureBlobStorage.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <PackageId>MultiLock.AzureBlobStorage</PackageId>
-    <Description>Azure Blob Storage provider for MultiLock - Leader Election framework for distributed systems. This package includes the core MultiLock framework.</Description>
-    <PackageTags>leader-election;distributed-systems;high-availability;failover;azure;blob-storage;cloud</PackageTags>
+    <Description>Azure Blob Storage provider for MultiLock - Leader Election and Distributed Semaphores framework for distributed systems. This package includes the core MultiLock framework.</Description>
+    <PackageTags>leader-election;distributed-systems;high-availability;failover;semaphore;rate-limiting;azure;blob-storage;cloud</PackageTags>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Providers/MultiLock.Consul/ConsulLeaderElectionOptions.cs
+++ b/src/Providers/MultiLock.Consul/ConsulLeaderElectionOptions.cs
@@ -55,7 +55,7 @@ public sealed class ConsulLeaderElectionOptions
         if (SessionTtl < TimeSpan.FromSeconds(10) || SessionTtl > TimeSpan.FromHours(24))
             throw new ArgumentException("Session TTL must be between 10 seconds and 24 hours.", nameof(SessionTtl));
 
-        if (SessionLockDelay < TimeSpan.Zero || SessionLockDelay > TimeSpan.FromMinutes(60))
-            throw new ArgumentException("Session lock delay must be between 0 and 60 minutes.", nameof(SessionLockDelay));
+        if (SessionLockDelay < TimeSpan.Zero || SessionLockDelay > TimeSpan.FromSeconds(60))
+            throw new ArgumentException("Session lock delay must be between 0 and 60 seconds.", nameof(SessionLockDelay));
     }
 }

--- a/src/Providers/MultiLock.Consul/ConsulSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.Consul/ConsulSemaphoreOptions.cs
@@ -1,0 +1,62 @@
+﻿namespace MultiLock.Consul;
+
+/// <summary>
+/// Configuration options for the Consul semaphore provider.
+/// </summary>
+public sealed class ConsulSemaphoreOptions
+{
+    /// <summary>
+    /// Gets or sets the Consul server address.
+    /// Default is "http://localhost:8500".
+    /// </summary>
+    public string Address { get; set; } = "http://localhost:8500";
+
+    /// <summary>
+    /// Gets or sets the datacenter name.
+    /// If not specified, uses the default datacenter.
+    /// </summary>
+    public string? Datacenter { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ACL token for authentication.
+    /// </summary>
+    public string? Token { get; set; }
+
+    /// <summary>
+    /// Gets or sets the key prefix for semaphore keys.
+    /// Default is "semaphores".
+    /// </summary>
+    public string KeyPrefix { get; set; } = "semaphores";
+
+    /// <summary>
+    /// Gets or sets the session TTL for Consul sessions.
+    /// Default is 60 seconds.
+    /// </summary>
+    public TimeSpan SessionTtl { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Gets or sets the session lock delay.
+    /// Default is 15 seconds.
+    /// </summary>
+    public TimeSpan SessionLockDelay { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Validates the configuration options.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when configuration is invalid.</exception>
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(Address))
+            throw new ArgumentException("Address cannot be null or empty.", nameof(Address));
+
+        if (string.IsNullOrWhiteSpace(KeyPrefix))
+            throw new ArgumentException("Key prefix cannot be null or empty.", nameof(KeyPrefix));
+
+        if (SessionTtl < TimeSpan.FromSeconds(10) || SessionTtl > TimeSpan.FromHours(24))
+            throw new ArgumentException("Session TTL must be between 10 seconds and 24 hours.", nameof(SessionTtl));
+
+        if (SessionLockDelay < TimeSpan.Zero || SessionLockDelay > TimeSpan.FromSeconds(60))
+            throw new ArgumentException("Session lock delay must be between 0 and 60 seconds.", nameof(SessionLockDelay));
+    }
+}
+

--- a/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
@@ -1,0 +1,508 @@
+﻿using System.Text;
+using System.Text.Json;
+using Consul;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.Exceptions;
+
+namespace MultiLock.Consul;
+
+/// <summary>
+/// Consul implementation of the semaphore provider.
+/// Uses Consul sessions and key-value store for distributed semaphore coordination.
+/// </summary>
+public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposable
+{
+    private readonly ConsulSemaphoreOptions options;
+    private readonly ILogger<ConsulSemaphoreProvider> logger;
+    private readonly ConsulClient consulClient;
+    private readonly Dictionary<string, Dictionary<string, string>> activeSessions = new();
+    private readonly object sessionLock = new();
+    private volatile bool isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConsulSemaphoreProvider"/> class.
+    /// </summary>
+    /// <param name="options">The Consul options.</param>
+    /// <param name="logger">The logger.</param>
+    public ConsulSemaphoreProvider(
+        IOptions<ConsulSemaphoreOptions> options,
+        ILogger<ConsulSemaphoreProvider> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+
+        this.options.Validate();
+
+        var consulConfig = new ConsulClientConfiguration
+        {
+            Address = new Uri(this.options.Address)
+        };
+
+        if (!string.IsNullOrEmpty(this.options.Datacenter))
+            consulConfig.Datacenter = this.options.Datacenter;
+
+        if (!string.IsNullOrEmpty(this.options.Token))
+            consulConfig.Token = this.options.Token;
+
+        consulClient = new ConsulClient(consulConfig);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAcquireAsync(
+        string semaphoreName,
+        string holderId,
+        int maxCount,
+        IReadOnlyDictionary<string, string> metadata,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMaxCount(maxCount);
+        ParameterValidation.ValidateMetadata(metadata);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+
+        try
+        {
+            // Check if we already have a session for this holder
+            string? existingSessionId = GetExistingSession(semaphoreName, holderId);
+            if (existingSessionId != null)
+            {
+                // Renew the session
+                WriteResult<SessionEntry>? renewResult = await consulClient.Session.Renew(existingSessionId, cancellationToken);
+                if (renewResult.Response != null)
+                {
+                    await UpdateHolderKeyAsync(semaphoreName, holderId, existingSessionId, metadata, cancellationToken);
+                    logger.LogInformation("Renewed slot for holder {HolderId} in semaphore {SemaphoreName}",
+                        holderId, semaphoreName);
+                    return true;
+                }
+                // Session expired, remove it
+                RemoveSession(semaphoreName, holderId);
+            }
+
+            // Pre-check: fast-fail before spending a session creation round-trip.
+            int currentCount = await GetCurrentCountAsync(semaphoreName, slotTimeout, cancellationToken);
+            if (currentCount >= maxCount)
+            {
+                logger.LogDebug("Failed to acquire slot for holder {HolderId} in semaphore {SemaphoreName} - full ({CurrentCount}/{MaxCount})",
+                    holderId, semaphoreName, currentCount, maxCount);
+                return false;
+            }
+
+            // Create a session for this holder.
+            // Track it locally so we can destroy it on any failure path before AddSession commits it.
+            string sessionId = await CreateSessionAsync(holderId, cancellationToken);
+            bool sessionRegistered = false;
+
+            try
+            {
+                string holderKey = GetHolderKey(semaphoreName, holderId);
+
+                var holderData = new HolderData
+                {
+                    HolderId = holderId,
+                    AcquiredAt = DateTimeOffset.UtcNow,
+                    LastHeartbeat = DateTimeOffset.UtcNow,
+                    Metadata = new Dictionary<string, string>(metadata),
+                    SessionId = sessionId
+                };
+
+                string json = JsonSerializer.Serialize(holderData);
+                byte[] value = Encoding.UTF8.GetBytes(json);
+
+                var kvPair = new KVPair(holderKey)
+                {
+                    Value = value,
+                    Session = sessionId
+                };
+
+                WriteResult<bool>? acquireResult = await consulClient.KV.Acquire(kvPair, cancellationToken);
+
+                if (!acquireResult.Response)
+                {
+                    logger.LogDebug("Failed to acquire slot for holder {HolderId} in semaphore {SemaphoreName}",
+                        holderId, semaphoreName);
+                    return false;
+                }
+
+                // Post-acquisition safety check: multiple callers may have passed the pre-check
+                // simultaneously. If our acquisition pushed the live count over maxCount, roll back
+                // by destroying the session, which auto-deletes the holder key (SessionBehavior.Delete).
+                int postCount = await GetCurrentCountAsync(semaphoreName, slotTimeout, cancellationToken);
+                if (postCount > maxCount)
+                {
+                    logger.LogDebug(
+                        "Rolled back slot for holder {HolderId} in semaphore {SemaphoreName} - concurrent acquisition exceeded maxCount",
+                        holderId, semaphoreName);
+                    return false;
+                }
+
+                AddSession(semaphoreName, holderId, sessionId);
+                sessionRegistered = true;
+                logger.LogInformation("Acquired slot for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+                return true;
+            }
+            finally
+            {
+                // Destroy the Consul session if we didn't successfully register it locally.
+                // This prevents orphaned sessions when an exception occurs between CreateSession
+                // and AddSession, or when we decide to roll back (Acquire returned false, post-count exceeded).
+                if (!sessionRegistered)
+                {
+                    try
+                    {
+                        await consulClient.Session.Destroy(sessionId, CancellationToken.None);
+                    }
+                    catch (Exception cleanupEx)
+                    {
+                        logger.LogWarning(cleanupEx,
+                            "Failed to destroy orphaned Consul session {SessionId} for holder {HolderId}",
+                            sessionId, holderId);
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not SemaphoreException)
+        {
+            logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to acquire semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+
+        try
+        {
+            // Look up without removing first: if Destroy fails the local mapping is preserved,
+            // so a subsequent ReleaseAsync call can retry.
+            string? sessionId = GetExistingSession(semaphoreName, holderId);
+            if (sessionId == null)
+            {
+                logger.LogDebug("No active session found for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+                return;
+            }
+
+            await consulClient.Session.Destroy(sessionId, cancellationToken);
+            // Only remove from local state after a successful Destroy.
+            RemoveSession(semaphoreName, holderId);
+            logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to release semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateHeartbeatAsync(
+        string semaphoreName,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMetadata(metadata);
+
+        try
+        {
+            string? sessionId = GetExistingSession(semaphoreName, holderId);
+            if (sessionId == null)
+            {
+                logger.LogWarning("Heartbeat update failed for holder {HolderId} in semaphore {SemaphoreName} - not a holder",
+                    holderId, semaphoreName);
+                return false;
+            }
+
+            WriteResult<SessionEntry>? renewResult = await consulClient.Session.Renew(sessionId, cancellationToken);
+            if (renewResult.Response == null)
+            {
+                RemoveSession(semaphoreName, holderId);
+                return false;
+            }
+
+            await UpdateHolderKeyAsync(semaphoreName, holderId, sessionId, metadata, cancellationToken);
+            logger.LogDebug("Updated heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to update heartbeat", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetCurrentCountAsync(
+        string semaphoreName,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+
+        try
+        {
+            // Consul session TTL governs expiry, so listing active KV entries gives the live count.
+            string prefix = GetSemaphorePrefix(semaphoreName);
+            QueryResult<KVPair[]>? listResult = await consulClient.KV.List(prefix, cancellationToken);
+            return listResult.Response?.Length ?? 0;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting current count for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get current count", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SemaphoreHolder>> GetHoldersAsync(
+        string semaphoreName,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+
+        try
+        {
+            string prefix = GetSemaphorePrefix(semaphoreName);
+            QueryResult<KVPair[]>? listResult = await consulClient.KV.List(prefix, cancellationToken);
+
+            if (listResult.Response == null)
+                return [];
+
+            var holders = new List<SemaphoreHolder>();
+            foreach (KVPair kvPair in listResult.Response)
+            {
+                if (kvPair.Value == null) continue;
+                HolderData? holderData = JsonSerializer.Deserialize<HolderData>(Encoding.UTF8.GetString(kvPair.Value));
+                if (holderData != null)
+                    holders.Add(new SemaphoreHolder(holderData.HolderId, holderData.AcquiredAt, holderData.LastHeartbeat, holderData.Metadata));
+            }
+            return holders;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get holders", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsHoldingAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+
+        try
+        {
+            string holderKey = GetHolderKey(semaphoreName, holderId);
+            QueryResult<KVPair>? getResult = await consulClient.KV.Get(holderKey, cancellationToken);
+            return getResult.Response?.Value != null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error checking if holder {HolderId} is holding semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to check holding status", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
+    {
+        if (isDisposed)
+            return false;
+
+        try
+        {
+            QueryResult<Dictionary<string, Dictionary<string, dynamic>>>? result = await consulClient.Agent.Self(cancellationToken);
+            return result.StatusCode == System.Net.HttpStatusCode.OK;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Health check failed for Consul semaphore provider");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (isDisposed) return;
+        isDisposed = true;
+
+        var sessionsToDestroy = new List<string>();
+        lock (sessionLock)
+        {
+            foreach (Dictionary<string, string> holderSessions in activeSessions.Values)
+                sessionsToDestroy.AddRange(holderSessions.Values);
+            activeSessions.Clear();
+        }
+
+        foreach (string sessionId in sessionsToDestroy)
+        {
+            try
+            {
+                await consulClient.Session.Destroy(sessionId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Error destroying session {SessionId} during disposal", sessionId);
+            }
+        }
+
+        consulClient.Dispose();
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Prefer <see cref="DisposeAsync"/> in async contexts. This synchronous path blocks the
+    /// calling thread and should not be used when a synchronization context is active.
+    /// </remarks>
+    public void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (!isDisposed) return;
+        throw new ObjectDisposedException(nameof(ConsulSemaphoreProvider));
+    }
+
+    private async Task<string> CreateSessionAsync(string holderId, CancellationToken cancellationToken)
+    {
+        var sessionEntry = new SessionEntry
+        {
+            Name = $"semaphore-{holderId}",
+            TTL = options.SessionTtl,
+            LockDelay = options.SessionLockDelay,
+            Behavior = SessionBehavior.Delete
+        };
+
+        WriteResult<string>? createResult = await consulClient.Session.Create(sessionEntry, cancellationToken);
+        if (string.IsNullOrEmpty(createResult?.Response))
+            throw new SemaphoreProviderException("Failed to create Consul session: empty session ID returned.");
+        return createResult.Response;
+    }
+
+    private async Task UpdateHolderKeyAsync(
+        string semaphoreName,
+        string holderId,
+        string sessionId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken)
+    {
+        string holderKey = GetHolderKey(semaphoreName, holderId);
+        QueryResult<KVPair>? getResult = await consulClient.KV.Get(holderKey, cancellationToken);
+
+        if (getResult.Response?.Value == null)
+            return;
+
+        HolderData? existingData = JsonSerializer.Deserialize<HolderData>(Encoding.UTF8.GetString(getResult.Response.Value));
+        if (existingData == null)
+            return;
+
+        existingData.LastHeartbeat = DateTimeOffset.UtcNow;
+        existingData.Metadata = new Dictionary<string, string>(metadata);
+
+        string json = JsonSerializer.Serialize(existingData);
+        byte[] value = Encoding.UTF8.GetBytes(json);
+
+        var kvPair = new KVPair(holderKey)
+        {
+            Value = value,
+            Session = sessionId,
+            ModifyIndex = getResult.Response.ModifyIndex
+        };
+
+        WriteResult<bool> casResult = await consulClient.KV.CAS(kvPair, cancellationToken);
+        if (!casResult.Response)
+            logger.LogDebug("CAS heartbeat update for holder {HolderId} in semaphore {SemaphoreName} was rejected (concurrent modification)", holderId, semaphoreName);
+    }
+
+    private string GetSemaphorePrefix(string semaphoreName)
+    {
+        return $"{options.KeyPrefix}/{semaphoreName}/";
+    }
+
+    private string GetHolderKey(string semaphoreName, string holderId)
+    {
+        return $"{options.KeyPrefix}/{semaphoreName}/{holderId}";
+    }
+
+    private string? GetExistingSession(string semaphoreName, string holderId)
+    {
+        lock (sessionLock)
+        {
+            if (activeSessions.TryGetValue(semaphoreName, out Dictionary<string, string>? holderSessions))
+                if (holderSessions.TryGetValue(holderId, out string? sessionId))
+                    return sessionId;
+            return null;
+        }
+    }
+
+    private void AddSession(string semaphoreName, string holderId, string sessionId)
+    {
+        lock (sessionLock)
+        {
+            if (!activeSessions.TryGetValue(semaphoreName, out Dictionary<string, string>? holderSessions))
+            {
+                holderSessions = new Dictionary<string, string>();
+                activeSessions[semaphoreName] = holderSessions;
+            }
+            holderSessions[holderId] = sessionId;
+        }
+    }
+
+    private string? RemoveSession(string semaphoreName, string holderId)
+    {
+        lock (sessionLock)
+        {
+            if (!activeSessions.TryGetValue(semaphoreName, out Dictionary<string, string>? holderSessions))
+                return null;
+            if (!holderSessions.Remove(holderId, out string? sessionId))
+                return null;
+            if (holderSessions.Count == 0)
+                activeSessions.Remove(semaphoreName);
+            return sessionId;
+        }
+    }
+
+    /// <summary>
+    /// Internal class to represent holder data stored in Consul.
+    /// </summary>
+    private sealed class HolderData
+    {
+        public string HolderId { get; init; } = string.Empty;
+        public DateTimeOffset AcquiredAt { get; init; }
+        public DateTimeOffset LastHeartbeat { get; set; }
+        public Dictionary<string, string> Metadata { get; set; } = new();
+        public string SessionId { get; init; } = string.Empty;
+    }
+}

--- a/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
@@ -193,7 +193,7 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
                 }
             }
         }
-        catch (Exception ex) when (ex is not SemaphoreException)
+        catch (Exception ex) when (ex is not SemaphoreException and not OperationCanceledException)
         {
             logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
@@ -229,7 +229,7 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
             logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
@@ -280,7 +280,7 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
                 holderId, semaphoreName);
             return true;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
@@ -308,7 +308,7 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
             QueryResult<KVPair[]>? listResult = await consulClient.KV.List(prefix, queryOptions, cancellationToken);
             return listResult.Response?.Length ?? 0;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error getting current count for semaphore {SemaphoreName}", semaphoreName);
             throw new SemaphoreProviderException("Failed to get current count", ex);
@@ -344,7 +344,7 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
             }
             return holders;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
             throw new SemaphoreProviderException("Failed to get holders", ex);
@@ -367,7 +367,7 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
             QueryResult<KVPair>? getResult = await consulClient.KV.Get(holderKey, cancellationToken);
             return getResult.Response?.Value != null;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error checking if holder {HolderId} is holding semaphore {SemaphoreName}",
                 holderId, semaphoreName);
@@ -386,7 +386,7 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
             QueryResult<Dictionary<string, Dictionary<string, dynamic>>>? result = await consulClient.Agent.Self(cancellationToken);
             return result.StatusCode == System.Net.HttpStatusCode.OK;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogWarning(ex, "Health check failed for Consul semaphore provider");
             return false;

--- a/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
@@ -83,10 +83,23 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
                 // Renew the session, but only treat this as a successful renewal if the holder key
                 // still exists. The session can outlive its key (e.g. the key was deleted out of
                 // band), in which case the slot is genuinely lost and we must re-acquire rather than
-                // falsely report success.
-                WriteResult<SessionEntry>? renewResult = await consulClient.Session.Renew(existingSessionId, cancellationToken);
-                if (renewResult.Response != null
-                    && await UpdateHolderKeyAsync(semaphoreName, holderId, existingSessionId, metadata, cancellationToken))
+                // falsely report success. Session.Renew THROWS SessionExpiredException (rather than
+                // returning a null response) when the session no longer exists, so treat that the
+                // same as a failed renewal and fall through to the re-acquire path below.
+                bool renewed = false;
+                try
+                {
+                    WriteResult<SessionEntry>? renewResult = await consulClient.Session.Renew(existingSessionId, cancellationToken);
+                    renewed = renewResult.Response != null
+                        && await UpdateHolderKeyAsync(semaphoreName, holderId, existingSessionId, metadata, cancellationToken);
+                }
+                catch (SessionExpiredException ex)
+                {
+                    logger.LogWarning(ex, "Consul session {SessionId} for holder {HolderId} in semaphore {SemaphoreName} has expired",
+                        existingSessionId, holderId, semaphoreName);
+                }
+
+                if (renewed)
                 {
                     logger.LogInformation("Renewed slot for holder {HolderId} in semaphore {SemaphoreName}",
                         holderId, semaphoreName);
@@ -259,7 +272,24 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
                 return false;
             }
 
-            WriteResult<SessionEntry>? renewResult = await consulClient.Session.Renew(sessionId, cancellationToken);
+            // Session.Renew THROWS SessionExpiredException (rather than returning a null response)
+            // when the session no longer exists, e.g. after a network partition longer than the TTL.
+            // It must be reported as a failed heartbeat (false), not as a provider error: an
+            // exception here would be retried and logged by the service while it keeps believing it
+            // holds a slot it has permanently lost.
+            WriteResult<SessionEntry>? renewResult;
+            try
+            {
+                renewResult = await consulClient.Session.Renew(sessionId, cancellationToken);
+            }
+            catch (SessionExpiredException ex)
+            {
+                RemoveSession(semaphoreName, holderId);
+                logger.LogWarning(ex, "Consul session {SessionId} for holder {HolderId} in semaphore {SemaphoreName} has expired - slot lost",
+                    sessionId, holderId, semaphoreName);
+                return false;
+            }
+
             if (renewResult.Response == null)
             {
                 RemoveSession(semaphoreName, holderId);

--- a/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
@@ -11,6 +11,16 @@ namespace MultiLock.Consul;
 /// Consul implementation of the semaphore provider.
 /// Uses Consul sessions and key-value store for distributed semaphore coordination.
 /// </summary>
+/// <remarks>
+/// Each holder writes its own session-bound key, so acquisition is bounded <em>optimistically</em>
+/// rather than via a single atomic compare-and-set: a strongly consistent pre-check is followed by
+/// the acquire and a strongly consistent post-check that rolls back (destroys the session, which
+/// deletes the key) if the live count exceeded <c>maxCount</c>. This never grants more than
+/// <c>maxCount</c> slots under consistent reads, but under heavy contention competing callers may
+/// transiently roll each other back and spuriously report the semaphore as full; callers retry on
+/// their normal acquisition interval. All count reads use <see cref="ConsistencyMode.Consistent"/>;
+/// correctness depends on that consistency guarantee.
+/// </remarks>
 public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposable
 {
     private readonly ConsulSemaphoreOptions options;
@@ -70,20 +80,37 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
             string? existingSessionId = GetExistingSession(semaphoreName, holderId);
             if (existingSessionId != null)
             {
-                // Renew the session
+                // Renew the session, but only treat this as a successful renewal if the holder key
+                // still exists. The session can outlive its key (e.g. the key was deleted out of
+                // band), in which case the slot is genuinely lost and we must re-acquire rather than
+                // falsely report success.
                 WriteResult<SessionEntry>? renewResult = await consulClient.Session.Renew(existingSessionId, cancellationToken);
-                if (renewResult.Response != null)
+                if (renewResult.Response != null
+                    && await UpdateHolderKeyAsync(semaphoreName, holderId, existingSessionId, metadata, cancellationToken))
                 {
-                    await UpdateHolderKeyAsync(semaphoreName, holderId, existingSessionId, metadata, cancellationToken);
                     logger.LogInformation("Renewed slot for holder {HolderId} in semaphore {SemaphoreName}",
                         holderId, semaphoreName);
                     return true;
                 }
-                // Session expired, remove it
+
+                // Renewal failed or the slot was lost: drop the stale session before re-acquiring so
+                // it does not linger and consume capacity until its TTL expires.
                 RemoveSession(semaphoreName, holderId);
+                try
+                {
+                    await consulClient.Session.Destroy(existingSessionId, cancellationToken);
+                }
+                catch (Exception destroyEx)
+                {
+                    logger.LogDebug(destroyEx,
+                        "Failed to destroy stale session {SessionId} for holder {HolderId} before re-acquire",
+                        existingSessionId, holderId);
+                }
             }
 
-            // Pre-check: fast-fail before spending a session creation round-trip.
+            // Pre-check: fast-fail before spending a session creation round-trip. This is only an
+            // optimisation hint; correctness is enforced by the post-acquisition check below, which
+            // (like this one) reads with strong consistency so the count reflects committed state.
             int currentCount = await GetCurrentCountAsync(semaphoreName, slotTimeout, cancellationToken);
             if (currentCount >= maxCount)
             {
@@ -239,7 +266,16 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
                 return false;
             }
 
-            await UpdateHolderKeyAsync(semaphoreName, holderId, sessionId, metadata, cancellationToken);
+            // If the holder key has been reaped the slot is lost even though the session renewed;
+            // drop local tracking and report the heartbeat as failed so the service re-acquires.
+            if (!await UpdateHolderKeyAsync(semaphoreName, holderId, sessionId, metadata, cancellationToken))
+            {
+                RemoveSession(semaphoreName, holderId);
+                logger.LogWarning("Heartbeat update for holder {HolderId} in semaphore {SemaphoreName} found no holder key - slot lost",
+                    holderId, semaphoreName);
+                return false;
+            }
+
             logger.LogDebug("Updated heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
             return true;
@@ -264,8 +300,12 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
         try
         {
             // Consul session TTL governs expiry, so listing active KV entries gives the live count.
+            // Use a strongly consistent read (not the default, which may serve a stale follower
+            // response): the acquire path relies on this count for its pre/post capacity checks, so
+            // an under-count from a stale replica could let the holder count exceed maxCount.
             string prefix = GetSemaphorePrefix(semaphoreName);
-            QueryResult<KVPair[]>? listResult = await consulClient.KV.List(prefix, cancellationToken);
+            var queryOptions = new QueryOptions { Consistency = ConsistencyMode.Consistent };
+            QueryResult<KVPair[]>? listResult = await consulClient.KV.List(prefix, queryOptions, cancellationToken);
             return listResult.Response?.Length ?? 0;
         }
         catch (Exception ex)
@@ -298,6 +338,9 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
                 HolderData? holderData = JsonSerializer.Deserialize<HolderData>(Encoding.UTF8.GetString(kvPair.Value));
                 if (holderData != null)
                     holders.Add(new SemaphoreHolder(holderData.HolderId, holderData.AcquiredAt, holderData.LastHeartbeat, holderData.Metadata));
+                else
+                    logger.LogWarning("Skipping holder key {Key} in semaphore {SemaphoreName} - data could not be deserialized",
+                        kvPair.Key, semaphoreName);
             }
             return holders;
         }
@@ -411,7 +454,14 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
         return createResult.Response;
     }
 
-    private async Task UpdateHolderKeyAsync(
+    /// <summary>
+    /// Refreshes the holder key's heartbeat and metadata.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the holder key still exists (and the heartbeat was refreshed);
+    /// <c>false</c> if the key no longer exists, meaning the slot has been lost.
+    /// </returns>
+    private async Task<bool> UpdateHolderKeyAsync(
         string semaphoreName,
         string holderId,
         string sessionId,
@@ -422,11 +472,16 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
         QueryResult<KVPair>? getResult = await consulClient.KV.Get(holderKey, cancellationToken);
 
         if (getResult.Response?.Value == null)
-            return;
+            return false;
 
         HolderData? existingData = JsonSerializer.Deserialize<HolderData>(Encoding.UTF8.GetString(getResult.Response.Value));
         if (existingData == null)
-            return;
+        {
+            logger.LogWarning(
+                "Holder key {HolderKey} in semaphore {SemaphoreName} contained data that could not be deserialized; treating the slot as lost",
+                holderKey, semaphoreName);
+            return false;
+        }
 
         existingData.LastHeartbeat = DateTimeOffset.UtcNow;
         existingData.Metadata = new Dictionary<string, string>(metadata);
@@ -444,6 +499,10 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
         WriteResult<bool> casResult = await consulClient.KV.CAS(kvPair, cancellationToken);
         if (!casResult.Response)
             logger.LogDebug("CAS heartbeat update for holder {HolderId} in semaphore {SemaphoreName} was rejected (concurrent modification)", holderId, semaphoreName);
+
+        // The key existed; a rejected CAS just means a concurrent refresh won the race, which still
+        // means the holder is alive. Only a missing key (handled above) indicates a lost slot.
+        return true;
     }
 
     private string GetSemaphorePrefix(string semaphoreName)

--- a/src/Providers/MultiLock.Consul/ConsulServiceCollectionExtensions.cs
+++ b/src/Providers/MultiLock.Consul/ConsulServiceCollectionExtensions.cs
@@ -3,10 +3,12 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MultiLock.Consul;
 
 /// <summary>
-/// Extension methods for configuring Consul leader election services.
+/// Extension methods for configuring Consul leader election and semaphore services.
 /// </summary>
 public static class ConsulServiceCollectionExtensions
 {
+    // Leader Election Methods
+
     /// <summary>
     /// Adds Consul leader election services to the dependency injection container.
     /// </summary>
@@ -65,5 +67,67 @@ public static class ConsulServiceCollectionExtensions
                 options.Token = token;
             },
             configureLeaderElectionOptions);
+    }
+
+    // Semaphore Methods
+
+    /// <summary>
+    /// Adds Consul semaphore services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the Consul options.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddConsulSemaphore(
+        this IServiceCollection services,
+        Action<ConsulSemaphoreOptions> configureOptions,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        services.Configure(configureOptions);
+
+        if (configureSemaphoreOptions != null)
+            services.Configure(configureSemaphoreOptions);
+
+        return services.AddSemaphore<ConsulSemaphoreProvider>();
+    }
+
+    /// <summary>
+    /// Adds Consul semaphore services to the dependency injection container with address.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="address">The Consul server address.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddConsulSemaphore(
+        this IServiceCollection services,
+        string address,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddConsulSemaphore(
+            options => options.Address = address,
+            configureSemaphoreOptions);
+    }
+
+    /// <summary>
+    /// Adds Consul semaphore services to the dependency injection container with address and token.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="address">The Consul server address.</param>
+    /// <param name="token">The ACL token for authentication.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddConsulSemaphore(
+        this IServiceCollection services,
+        string address,
+        string token,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddConsulSemaphore(
+            options =>
+            {
+                options.Address = address;
+                options.Token = token;
+            },
+            configureSemaphoreOptions);
     }
 }

--- a/src/Providers/MultiLock.Consul/MultiLock.Consul.csproj
+++ b/src/Providers/MultiLock.Consul/MultiLock.Consul.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <PackageId>MultiLock.Consul</PackageId>
-    <Description>HashiCorp Consul provider for MultiLock - Leader Election framework for distributed systems. This package includes the core MultiLock framework.</Description>
-    <PackageTags>leader-election;distributed-systems;high-availability;failover;consul;hashicorp;service-mesh</PackageTags>
+    <Description>HashiCorp Consul provider for MultiLock - Leader Election and Distributed Semaphores framework for distributed systems. This package includes the core MultiLock framework.</Description>
+    <PackageTags>leader-election;distributed-systems;high-availability;failover;semaphore;rate-limiting;consul;hashicorp;service-mesh</PackageTags>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Providers/MultiLock.FileSystem/FileSystemSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.FileSystem/FileSystemSemaphoreOptions.cs
@@ -1,0 +1,42 @@
+﻿namespace MultiLock.FileSystem;
+
+/// <summary>
+/// Configuration options for the File System semaphore provider.
+/// </summary>
+public sealed class FileSystemSemaphoreOptions
+{
+    /// <summary>
+    /// Gets or sets the directory path where semaphore files will be stored.
+    /// Default is a "Semaphores" subdirectory in the system temp directory.
+    /// </summary>
+    public string DirectoryPath { get; set; } = Path.Combine(Path.GetTempPath(), "Semaphores");
+
+    /// <summary>
+    /// Gets or sets the file extension for semaphore holder files.
+    /// Default is ".holder".
+    /// </summary>
+    public string FileExtension { get; set; } = ".holder";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically create the directory if it doesn't exist.
+    /// Default is true.
+    /// </summary>
+    public bool AutoCreateDirectory { get; set; } = true;
+
+    /// <summary>
+    /// Validates the configuration options.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when configuration is invalid.</exception>
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(DirectoryPath))
+            throw new ArgumentException("Directory path cannot be null or empty.", nameof(DirectoryPath));
+
+        if (string.IsNullOrWhiteSpace(FileExtension))
+            throw new ArgumentException("File extension cannot be null or empty.", nameof(FileExtension));
+
+        if (!FileExtension.StartsWith('.') || FileExtension.Length < 2)
+            throw new ArgumentException("File extension must start with '.' and have at least one character after it (e.g. '.holder').", nameof(FileExtension));
+    }
+}
+

--- a/src/Providers/MultiLock.FileSystem/FileSystemSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.FileSystem/FileSystemSemaphoreProvider.cs
@@ -1,0 +1,492 @@
+﻿using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.Exceptions;
+
+namespace MultiLock.FileSystem;
+
+/// <summary>
+/// File System implementation of the semaphore provider.
+/// Uses files in a directory to track semaphore holders.
+/// </summary>
+public sealed class FileSystemSemaphoreProvider : ISemaphoreProvider
+{
+    private readonly FileSystemSemaphoreOptions options;
+    private readonly ILogger<FileSystemSemaphoreProvider> logger;
+    private readonly SemaphoreSlim initializationLock = new(1, 1);
+    private readonly object fileLock = new();
+    private volatile bool isInitialized;
+    private volatile bool isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystemSemaphoreProvider"/> class.
+    /// </summary>
+    /// <param name="options">The file system options.</param>
+    /// <param name="logger">The logger.</param>
+    public FileSystemSemaphoreProvider(
+        IOptions<FileSystemSemaphoreOptions> options,
+        ILogger<FileSystemSemaphoreProvider> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+
+        this.options.Validate();
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAcquireAsync(
+        string semaphoreName,
+        string holderId,
+        int maxCount,
+        IReadOnlyDictionary<string, string> metadata,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMaxCount(maxCount);
+        ParameterValidation.ValidateMetadata(metadata);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            string semaphoreDir = GetSemaphoreDirectory(semaphoreName);
+            EnsureDirectoryExists(semaphoreDir);
+
+            // Use a per-semaphore OS lock file so that the count-then-create operation is
+            // atomic across processes (not just across threads). lock(fileLock) alone is a
+            // C# monitor and has no cross-process effect. The lock file is held open with
+            // FileShare.None for the duration of the critical section; closing/disposing the
+            // FileStream releases the OS lock automatically.
+            string lockFilePath = Path.Combine(semaphoreDir, ".lock");
+            await using FileStream lockFile = await AcquireLockFileAsync(lockFilePath, cancellationToken);
+
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            DateTimeOffset expiryTime = now.Subtract(slotTimeout);
+
+            // Clean up expired holders
+            CleanupExpiredHolders(semaphoreDir, expiryTime);
+
+            // Check if holder already exists (renewal)
+            string holderFilePath = GetHolderFilePath(semaphoreDir, holderId);
+            if (File.Exists(holderFilePath))
+            {
+                HolderFileContent? existingHolder = ReadHolderFile(holderFilePath);
+                if (existingHolder != null)
+                {
+                    existingHolder.LastHeartbeat = now;
+                    existingHolder.Metadata = new Dictionary<string, string>(metadata);
+                    WriteHolderFile(holderFilePath, existingHolder);
+                    logger.LogInformation("Renewed slot for holder {HolderId} in semaphore {SemaphoreName}",
+                        holderId, semaphoreName);
+                    return true;
+                }
+            }
+
+            // Count only valid, non-expired holders; corrupt or unreadable files must not
+            // consume capacity since CleanupExpiredHolders leaves them in place.
+            int currentCount = CountActiveHolders(semaphoreDir, expiryTime);
+            if (currentCount >= maxCount)
+            {
+                logger.LogDebug("Failed to acquire slot for holder {HolderId} in semaphore {SemaphoreName} - full ({CurrentCount}/{MaxCount})",
+                    holderId, semaphoreName, currentCount, maxCount);
+                return false;
+            }
+
+            // Create new holder file
+            var holderContent = new HolderFileContent
+            {
+                HolderId = holderId,
+                AcquiredAt = now,
+                LastHeartbeat = now,
+                Metadata = new Dictionary<string, string>(metadata)
+            };
+
+            WriteHolderFile(holderFilePath, holderContent);
+            logger.LogInformation("Acquired slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to acquire semaphore slot", ex);
+        }
+    }
+
+    // Polls until the per-semaphore OS lock file can be opened exclusively (FileShare.None).
+    // This provides cross-process mutual exclusion for the count-and-acquire critical section.
+    private static async Task<FileStream> AcquireLockFileAsync(string lockFilePath, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                return new FileStream(lockFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException)
+            {
+                await Task.Delay(10, cancellationToken);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            string semaphoreDir = GetSemaphoreDirectory(semaphoreName);
+
+            // If the directory doesn't exist there is nothing to release.
+            if (!Directory.Exists(semaphoreDir))
+            {
+                logger.LogDebug("Holder {HolderId} not found in semaphore {SemaphoreName}", holderId, semaphoreName);
+                return;
+            }
+
+            // Use the same per-semaphore OS lock file as TryAcquireAsync to prevent
+            // cross-process races between concurrent Release / Heartbeat / Acquire calls.
+            string lockFilePath = Path.Combine(semaphoreDir, ".lock");
+            await using FileStream lockFile = await AcquireLockFileAsync(lockFilePath, cancellationToken);
+
+            string holderFilePath = GetHolderFilePath(semaphoreDir, holderId);
+            if (File.Exists(holderFilePath))
+            {
+                File.Delete(holderFilePath);
+                logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+            }
+            else
+            {
+                logger.LogDebug("Holder {HolderId} not found in semaphore {SemaphoreName}", holderId, semaphoreName);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to release semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateHeartbeatAsync(
+        string semaphoreName,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMetadata(metadata);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            string semaphoreDir = GetSemaphoreDirectory(semaphoreName);
+
+            if (!Directory.Exists(semaphoreDir))
+            {
+                logger.LogWarning("Heartbeat update failed for holder {HolderId} in semaphore {SemaphoreName} - not a holder",
+                    holderId, semaphoreName);
+                return false;
+            }
+
+            // Use the same per-semaphore OS lock file as TryAcquireAsync to prevent
+            // cross-process races between concurrent Heartbeat / Release / Acquire calls.
+            string lockFilePath = Path.Combine(semaphoreDir, ".lock");
+            await using FileStream lockFile = await AcquireLockFileAsync(lockFilePath, cancellationToken);
+
+            string holderFilePath = GetHolderFilePath(semaphoreDir, holderId);
+            if (!File.Exists(holderFilePath))
+            {
+                logger.LogWarning("Heartbeat update failed for holder {HolderId} in semaphore {SemaphoreName} - not a holder",
+                    holderId, semaphoreName);
+                return false;
+            }
+
+            HolderFileContent? holder = ReadHolderFile(holderFilePath);
+            if (holder == null)
+                return false;
+
+            holder.LastHeartbeat = DateTimeOffset.UtcNow;
+            holder.Metadata = new Dictionary<string, string>(metadata);
+            WriteHolderFile(holderFilePath, holder);
+
+            logger.LogDebug("Updated heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to update heartbeat", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetCurrentCountAsync(
+        string semaphoreName,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            lock (fileLock)
+            {
+                string semaphoreDir = GetSemaphoreDirectory(semaphoreName);
+                if (!Directory.Exists(semaphoreDir))
+                    return 0;
+
+                DateTimeOffset expiryTime = DateTimeOffset.UtcNow.Subtract(slotTimeout);
+                return CountActiveHolders(semaphoreDir, expiryTime);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting current count for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get current count", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SemaphoreHolder>> GetHoldersAsync(
+        string semaphoreName,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            lock (fileLock)
+            {
+                string semaphoreDir = GetSemaphoreDirectory(semaphoreName);
+                if (!Directory.Exists(semaphoreDir))
+                    return [];
+
+                var holders = new List<SemaphoreHolder>();
+                foreach (string filePath in Directory.GetFiles(semaphoreDir, $"*{options.FileExtension}"))
+                {
+                    HolderFileContent? holder = ReadHolderFile(filePath);
+                    if (holder != null)
+                        holders.Add(new SemaphoreHolder(holder.HolderId, holder.AcquiredAt, holder.LastHeartbeat, holder.Metadata));
+                }
+                return holders;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get holders", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsHoldingAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            lock (fileLock)
+            {
+                string semaphoreDir = GetSemaphoreDirectory(semaphoreName);
+                string holderFilePath = GetHolderFilePath(semaphoreDir, holderId);
+                return File.Exists(holderFilePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error checking if holder {HolderId} is holding semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to check holding status", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
+    {
+        if (isDisposed)
+            return false;
+
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken);
+            return Directory.Exists(options.DirectoryPath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Health check failed for File System semaphore provider");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (isDisposed) return;
+        isDisposed = true;
+        initializationLock.Dispose();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (!isDisposed) return;
+        throw new ObjectDisposedException(nameof(FileSystemSemaphoreProvider));
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (isInitialized)
+            return;
+
+        await initializationLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (isInitialized)
+                return;
+
+            if (options.AutoCreateDirectory && !Directory.Exists(options.DirectoryPath))
+            {
+                Directory.CreateDirectory(options.DirectoryPath);
+                logger.LogInformation("Created semaphore directory: {DirectoryPath}", options.DirectoryPath);
+            }
+
+            isInitialized = true;
+        }
+        finally
+        {
+            initializationLock.Release();
+        }
+    }
+
+    private string GetSemaphoreDirectory(string semaphoreName)
+    {
+        // Normalize the base path so Path.GetFullPath comparisons are correct.
+        string basePath = Path.GetFullPath(options.DirectoryPath).TrimEnd(Path.DirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+
+        string candidatePath = Path.GetFullPath(Path.Combine(options.DirectoryPath, semaphoreName));
+
+        // Reject paths that resolve outside the configured base directory (e.g. "..").
+        if (!candidatePath.StartsWith(basePath, StringComparison.Ordinal))
+            throw new ArgumentException(
+                $"Semaphore name '{semaphoreName}' resolves to a path outside the configured directory.",
+                nameof(semaphoreName));
+
+        return candidatePath;
+    }
+
+    private string GetHolderFilePath(string semaphoreDir, string holderId)
+    {
+        string normalizedDir = semaphoreDir.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        string candidatePath = Path.GetFullPath(Path.Combine(semaphoreDir, $"{holderId}{options.FileExtension}"));
+
+        if (!candidatePath.StartsWith(normalizedDir, StringComparison.Ordinal))
+            throw new ArgumentException(
+                $"Holder ID '{holderId}' resolves to a path outside the semaphore directory.",
+                nameof(holderId));
+
+        return candidatePath;
+    }
+
+    private static void EnsureDirectoryExists(string directoryPath)
+    {
+        if (!Directory.Exists(directoryPath))
+            Directory.CreateDirectory(directoryPath);
+    }
+
+    private void CleanupExpiredHolders(string semaphoreDir, DateTimeOffset expiryTime)
+    {
+        if (!Directory.Exists(semaphoreDir))
+            return;
+
+        foreach (string filePath in Directory.GetFiles(semaphoreDir, $"*{options.FileExtension}"))
+        {
+            try
+            {
+                HolderFileContent? holder = ReadHolderFile(filePath);
+                if (holder != null && holder.LastHeartbeat < expiryTime)
+                {
+                    File.Delete(filePath);
+                    logger.LogDebug("Cleaned up expired holder {HolderId}", holder.HolderId);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Error cleaning up holder file {FilePath}", filePath);
+            }
+        }
+    }
+
+    private int CountHolders(string semaphoreDir)
+    {
+        if (!Directory.Exists(semaphoreDir))
+            return 0;
+        return Directory.GetFiles(semaphoreDir, $"*{options.FileExtension}").Length;
+    }
+
+    private int CountActiveHolders(string semaphoreDir, DateTimeOffset expiryTime)
+    {
+        if (!Directory.Exists(semaphoreDir))
+            return 0;
+
+        return Directory.GetFiles(semaphoreDir, $"*{options.FileExtension}")
+            .Select(ReadHolderFile)
+            .Count(holder => holder != null && holder.LastHeartbeat >= expiryTime);
+    }
+
+    private static HolderFileContent? ReadHolderFile(string filePath)
+    {
+        try
+        {
+            string content = File.ReadAllText(filePath);
+            return JsonSerializer.Deserialize<HolderFileContent>(content);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void WriteHolderFile(string filePath, HolderFileContent content)
+    {
+        string json = JsonSerializer.Serialize(content, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(filePath, json);
+    }
+}

--- a/src/Providers/MultiLock.FileSystem/FileSystemSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.FileSystem/FileSystemSemaphoreProvider.cs
@@ -441,7 +441,15 @@ public sealed class FileSystemSemaphoreProvider : ISemaphoreProvider
             try
             {
                 HolderFileContent? holder = ReadHolderFile(filePath);
-                if (holder != null && holder.LastHeartbeat < expiryTime)
+                if (holder == null)
+                {
+                    // Unreadable/corrupt file. Because WriteHolderFile writes atomically a holder
+                    // file is never observed half-written, so a null parse means genuine corruption.
+                    // Remove it during cleanup so corrupt files cannot accumulate indefinitely.
+                    File.Delete(filePath);
+                    logger.LogWarning("Removed corrupt holder file {FilePath}", filePath);
+                }
+                else if (holder.LastHeartbeat < expiryTime)
                 {
                     File.Delete(filePath);
                     logger.LogDebug("Cleaned up expired holder {HolderId}", holder.HolderId);
@@ -487,6 +495,34 @@ public sealed class FileSystemSemaphoreProvider : ISemaphoreProvider
     private static void WriteHolderFile(string filePath, HolderFileContent content)
     {
         string json = JsonSerializer.Serialize(content, new JsonSerializerOptions { WriteIndented = true });
-        File.WriteAllText(filePath, json);
+
+        // Write atomically: serialise into a uniquely-named temp file in the same directory,
+        // flush it to disk, then atomically replace the target via File.Move(overwrite: true)
+        // (MoveFileEx with REPLACE_EXISTING). A crash mid-write can only ever leave behind a
+        // stray ".tmp-*" file, never a half-written holder file that CountActiveHolders would
+        // silently exclude — which would otherwise let the live count exceed maxCount.
+        string directory = Path.GetDirectoryName(filePath)!;
+        string tempPath = Path.Combine(directory, $"{Path.GetFileName(filePath)}.tmp-{Guid.NewGuid():N}");
+
+        try
+        {
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, filePath, overwrite: true);
+        }
+        catch
+        {
+            // Best-effort cleanup of the temp file if the move failed; never mask the original error.
+            try
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+            catch
+            {
+                // Ignore cleanup failures.
+            }
+
+            throw;
+        }
     }
 }

--- a/src/Providers/MultiLock.FileSystem/FileSystemServiceCollectionExtensions.cs
+++ b/src/Providers/MultiLock.FileSystem/FileSystemServiceCollectionExtensions.cs
@@ -3,10 +3,12 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MultiLock.FileSystem;
 
 /// <summary>
-/// Extension methods for configuring File System leader election services.
+/// Extension methods for configuring File System leader election and semaphore services.
 /// </summary>
 public static class FileSystemServiceCollectionExtensions
 {
+    // Leader Election Methods
+
     /// <summary>
     /// Adds File System leader election services to the dependency injection container.
     /// </summary>
@@ -42,5 +44,44 @@ public static class FileSystemServiceCollectionExtensions
         return services.AddFileSystemLeaderElection(
             options => options.DirectoryPath = directoryPath,
             configureLeaderElectionOptions);
+    }
+
+    // Semaphore Methods
+
+    /// <summary>
+    /// Adds File System semaphore services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the file system options.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddFileSystemSemaphore(
+        this IServiceCollection services,
+        Action<FileSystemSemaphoreOptions> configureOptions,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        services.Configure(configureOptions);
+
+        if (configureSemaphoreOptions != null)
+            services.Configure(configureSemaphoreOptions);
+
+        return services.AddSemaphore<FileSystemSemaphoreProvider>();
+    }
+
+    /// <summary>
+    /// Adds File System semaphore services to the dependency injection container with directory path.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="directoryPath">The directory path for semaphore files.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddFileSystemSemaphore(
+        this IServiceCollection services,
+        string directoryPath,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddFileSystemSemaphore(
+            options => options.DirectoryPath = directoryPath,
+            configureSemaphoreOptions);
     }
 }

--- a/src/Providers/MultiLock.FileSystem/HolderFileContent.cs
+++ b/src/Providers/MultiLock.FileSystem/HolderFileContent.cs
@@ -1,0 +1,28 @@
+﻿namespace MultiLock.FileSystem;
+
+/// <summary>
+/// Represents the content of a semaphore holder file.
+/// </summary>
+internal sealed class HolderFileContent
+{
+    /// <summary>
+    /// Gets or sets the holder identifier.
+    /// </summary>
+    public string HolderId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the timestamp when the slot was acquired.
+    /// </summary>
+    public DateTimeOffset AcquiredAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the last heartbeat.
+    /// </summary>
+    public DateTimeOffset LastHeartbeat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the metadata associated with this holder.
+    /// </summary>
+    public Dictionary<string, string> Metadata { get; set; } = new();
+}
+

--- a/src/Providers/MultiLock.FileSystem/MultiLock.FileSystem.csproj
+++ b/src/Providers/MultiLock.FileSystem/MultiLock.FileSystem.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <PackageId>MultiLock.FileSystem</PackageId>
-    <Description>File System provider for MultiLock - Leader Election framework for distributed systems. This package includes the core MultiLock framework.</Description>
-    <PackageTags>leader-election;distributed-systems;high-availability;failover;file-system;local</PackageTags>
+    <Description>File System provider for MultiLock - Leader Election and Distributed Semaphores framework for distributed systems. This package includes the core MultiLock framework.</Description>
+    <PackageTags>leader-election;distributed-systems;high-availability;failover;semaphore;rate-limiting;file-system;local</PackageTags>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Providers/MultiLock.InMemory/InMemorySemaphoreProvider.cs
+++ b/src/Providers/MultiLock.InMemory/InMemorySemaphoreProvider.cs
@@ -1,0 +1,254 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace MultiLock.InMemory;
+
+/// <summary>
+/// In-memory implementation of the semaphore provider.
+/// This provider is intended for testing and development scenarios only.
+/// It does not provide true distributed coordination across multiple processes or machines.
+/// </summary>
+public sealed class InMemorySemaphoreProvider : ISemaphoreProvider
+{
+    private readonly ILogger<InMemorySemaphoreProvider> logger;
+    // All access is serialized through @lock, so plain Dictionary is sufficient.
+    private readonly Dictionary<string, Dictionary<string, SemaphoreSlotRecord>> semaphores = new();
+    private readonly object @lock = new();
+    private volatile bool isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InMemorySemaphoreProvider"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    public InMemorySemaphoreProvider(ILogger<InMemorySemaphoreProvider> logger)
+    {
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task<bool> TryAcquireAsync(
+        string semaphoreName,
+        string holderId,
+        int maxCount,
+        IReadOnlyDictionary<string, string> metadata,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMaxCount(maxCount);
+        ParameterValidation.ValidateMetadata(metadata);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+
+        lock (@lock)
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            DateTimeOffset expiryTime = now.Subtract(slotTimeout);
+
+            if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
+            {
+                holders = new Dictionary<string, SemaphoreSlotRecord>();
+                semaphores[semaphoreName] = holders;
+            }
+
+            // Clean up expired slots
+            CleanupExpiredSlots(holders, expiryTime);
+
+            // Check if holder already has a slot
+            if (holders.TryGetValue(holderId, out SemaphoreSlotRecord? existingSlot))
+            {
+                // Renew the existing slot
+                var renewedSlot = new SemaphoreSlotRecord(holderId, existingSlot.AcquiredAt, now, new Dictionary<string, string>(metadata));
+                holders[holderId] = renewedSlot;
+
+                logger.LogDebug("Renewed existing slot for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+
+                return Task.FromResult(true);
+            }
+
+            // Check if there's room for a new slot
+            if (holders.Count >= maxCount)
+            {
+                logger.LogDebug("Semaphore {SemaphoreName} is full ({CurrentCount}/{MaxCount}). Cannot acquire slot for holder {HolderId}",
+                    semaphoreName, holders.Count, maxCount, holderId);
+
+                return Task.FromResult(false);
+            }
+
+            // Acquire a new slot
+            var newSlot = new SemaphoreSlotRecord(holderId, now, now, new Dictionary<string, string>(metadata));
+            holders[holderId] = newSlot;
+
+            logger.LogInformation("Successfully acquired slot for holder {HolderId} in semaphore {SemaphoreName} ({CurrentCount}/{MaxCount})",
+                holderId, semaphoreName, holders.Count, maxCount);
+
+            return Task.FromResult(true);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task ReleaseAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+
+        lock (@lock)
+        {
+            if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
+                return Task.CompletedTask;
+
+            if (holders.Remove(holderId))
+            {
+                logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<bool> UpdateHeartbeatAsync(
+        string semaphoreName,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMetadata(metadata);
+
+        lock (@lock)
+        {
+            if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
+            {
+                logger.LogWarning("Heartbeat update failed for holder {HolderId} in semaphore {SemaphoreName} - semaphore not found",
+                    holderId, semaphoreName);
+                return Task.FromResult(false);
+            }
+
+            if (!holders.TryGetValue(holderId, out SemaphoreSlotRecord? existingSlot))
+            {
+                logger.LogWarning("Heartbeat update failed for holder {HolderId} in semaphore {SemaphoreName} - not a current holder",
+                    holderId, semaphoreName);
+                return Task.FromResult(false);
+            }
+
+            var updatedSlot = new SemaphoreSlotRecord(
+                holderId,
+                existingSlot.AcquiredAt,
+                DateTimeOffset.UtcNow,
+                new Dictionary<string, string>(metadata));
+
+            holders[holderId] = updatedSlot;
+
+            logger.LogDebug("Updated heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+
+            return Task.FromResult(true);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<int> GetCurrentCountAsync(
+        string semaphoreName,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+
+        lock (@lock)
+        {
+            if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
+                return Task.FromResult(0);
+
+            DateTimeOffset expiryTime = DateTimeOffset.UtcNow.Subtract(slotTimeout);
+            int count = holders.Values.Count(slot => slot.LastHeartbeat >= expiryTime);
+            return Task.FromResult(count);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<SemaphoreHolder>> GetHoldersAsync(
+        string semaphoreName,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+
+        lock (@lock)
+        {
+            if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
+                return Task.FromResult<IReadOnlyList<SemaphoreHolder>>(Array.Empty<SemaphoreHolder>());
+
+            List<SemaphoreHolder> result = holders.Values
+                .Select(slot => new SemaphoreHolder(slot.HolderId, slot.AcquiredAt, slot.LastHeartbeat, slot.Metadata))
+                .ToList();
+
+            return Task.FromResult<IReadOnlyList<SemaphoreHolder>>(result);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsHoldingAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+
+        lock (@lock)
+        {
+            if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
+                return Task.FromResult(false);
+
+            return Task.FromResult(holders.ContainsKey(holderId));
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(!isDisposed);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Serialize with the same lock used by all read/write operations so concurrent
+        // Acquire/Release/Heartbeat calls see a fully consistent disposed state.
+        lock (@lock)
+        {
+            if (isDisposed) return;
+            isDisposed = true;
+            semaphores.Clear();
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (!isDisposed) return;
+        throw new ObjectDisposedException(nameof(InMemorySemaphoreProvider));
+    }
+
+    private static void CleanupExpiredSlots(Dictionary<string, SemaphoreSlotRecord> holders, DateTimeOffset expiryTime)
+    {
+        List<string> expiredKeys = holders
+            .Where(kvp => kvp.Value.LastHeartbeat < expiryTime)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (string key in expiredKeys)
+            holders.Remove(key);
+    }
+}

--- a/src/Providers/MultiLock.InMemory/InMemorySemaphoreProvider.cs
+++ b/src/Providers/MultiLock.InMemory/InMemorySemaphoreProvider.cs
@@ -42,6 +42,11 @@ public sealed class InMemorySemaphoreProvider : ISemaphoreProvider
 
         lock (@lock)
         {
+            // Re-check inside the lock: a caller can pass the pre-lock ThrowIfDisposed() and then
+            // block here while Dispose() runs (Dispose() takes the same lock). Without this check it
+            // would proceed to repopulate state on an already-disposed provider.
+            ThrowIfDisposed();
+
             DateTimeOffset now = DateTimeOffset.UtcNow;
             DateTimeOffset expiryTime = now.Subtract(slotTimeout);
 
@@ -99,6 +104,8 @@ public sealed class InMemorySemaphoreProvider : ISemaphoreProvider
 
         lock (@lock)
         {
+            ThrowIfDisposed();
+
             if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
                 return Task.CompletedTask;
 
@@ -126,6 +133,8 @@ public sealed class InMemorySemaphoreProvider : ISemaphoreProvider
 
         lock (@lock)
         {
+            ThrowIfDisposed();
+
             if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
             {
                 logger.LogWarning("Heartbeat update failed for holder {HolderId} in semaphore {SemaphoreName} - semaphore not found",
@@ -167,6 +176,8 @@ public sealed class InMemorySemaphoreProvider : ISemaphoreProvider
 
         lock (@lock)
         {
+            ThrowIfDisposed();
+
             if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
                 return Task.FromResult(0);
 
@@ -186,6 +197,8 @@ public sealed class InMemorySemaphoreProvider : ISemaphoreProvider
 
         lock (@lock)
         {
+            ThrowIfDisposed();
+
             if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
                 return Task.FromResult<IReadOnlyList<SemaphoreHolder>>(Array.Empty<SemaphoreHolder>());
 
@@ -209,6 +222,8 @@ public sealed class InMemorySemaphoreProvider : ISemaphoreProvider
 
         lock (@lock)
         {
+            ThrowIfDisposed();
+
             if (!semaphores.TryGetValue(semaphoreName, out Dictionary<string, SemaphoreSlotRecord>? holders))
                 return Task.FromResult(false);
 

--- a/src/Providers/MultiLock.InMemory/InMemoryServiceCollectionExtensions.cs
+++ b/src/Providers/MultiLock.InMemory/InMemoryServiceCollectionExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MultiLock.InMemory;
 
 /// <summary>
-/// Extension methods for configuring In-Memory leader election services.
+/// Extension methods for configuring In-Memory leader election and semaphore services.
 /// </summary>
 public static class InMemoryServiceCollectionExtensions
 {
@@ -18,5 +18,18 @@ public static class InMemoryServiceCollectionExtensions
         Action<LeaderElectionOptions>? configureOptions = null)
     {
         return services.AddLeaderElection<InMemoryLeaderElectionProvider>(configureOptions);
+    }
+
+    /// <summary>
+    /// Adds In-Memory semaphore services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddInMemorySemaphore(
+        this IServiceCollection services,
+        Action<SemaphoreOptions>? configureOptions = null)
+    {
+        return services.AddSemaphore<InMemorySemaphoreProvider>(configureOptions);
     }
 }

--- a/src/Providers/MultiLock.InMemory/MultiLock.InMemory.csproj
+++ b/src/Providers/MultiLock.InMemory/MultiLock.InMemory.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <PackageId>MultiLock.InMemory</PackageId>
-    <Description>In-Memory provider for MultiLock - Leader Election framework for distributed systems. Ideal for testing and development. This package includes the core MultiLock framework.</Description>
-    <PackageTags>leader-election;distributed-systems;high-availability;failover;in-memory;testing;development</PackageTags>
+    <Description>In-Memory provider for MultiLock - Leader Election and Distributed Semaphores framework for distributed systems. Ideal for testing and development. This package includes the core MultiLock framework.</Description>
+    <PackageTags>leader-election;distributed-systems;high-availability;failover;semaphore;rate-limiting;in-memory;testing;development</PackageTags>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Providers/MultiLock.InMemory/SemaphoreSlotRecord.cs
+++ b/src/Providers/MultiLock.InMemory/SemaphoreSlotRecord.cs
@@ -1,0 +1,11 @@
+﻿namespace MultiLock.InMemory;
+
+/// <summary>
+/// Internal record to store semaphore slot holder information.
+/// </summary>
+internal sealed record SemaphoreSlotRecord(
+    string HolderId,
+    DateTimeOffset AcquiredAt,
+    DateTimeOffset LastHeartbeat,
+    IReadOnlyDictionary<string, string> Metadata);
+

--- a/src/Providers/MultiLock.PostgreSQL/MultiLock.PostgreSQL.csproj
+++ b/src/Providers/MultiLock.PostgreSQL/MultiLock.PostgreSQL.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <PackageId>MultiLock.PostgreSQL</PackageId>
-    <Description>PostgreSQL provider for MultiLock - Leader Election framework for distributed systems. This package includes the core MultiLock framework.</Description>
-    <PackageTags>leader-election;distributed-systems;high-availability;failover;postgresql;postgres;database</PackageTags>
+    <Description>PostgreSQL provider for MultiLock - Leader Election and Distributed Semaphores framework for distributed systems. This package includes the core MultiLock framework.</Description>
+    <PackageTags>leader-election;distributed-systems;high-availability;failover;semaphore;rate-limiting;postgresql;postgres;database</PackageTags>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Providers/MultiLock.PostgreSQL/PostgreSQLServiceCollectionExtensions.cs
+++ b/src/Providers/MultiLock.PostgreSQL/PostgreSQLServiceCollectionExtensions.cs
@@ -3,10 +3,11 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MultiLock.PostgreSQL;
 
 /// <summary>
-/// Extension methods for configuring PostgreSQL leader election services.
+/// Extension methods for configuring PostgreSQL leader election and semaphore services.
 /// </summary>
 public static class PostgreSqlServiceCollectionExtensions
 {
+    // Leader Election Methods
     /// <summary>
     /// Adds PostgreSQL leader election services to the dependency injection container.
     /// </summary>
@@ -68,5 +69,70 @@ public static class PostgreSqlServiceCollectionExtensions
                 options.SchemaName = schemaName;
             },
             configureLeaderElectionOptions);
+    }
+
+    // Semaphore Methods
+
+    /// <summary>
+    /// Adds PostgreSQL semaphore services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the PostgreSQL options.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddPostgreSqlSemaphore(
+        this IServiceCollection services,
+        Action<PostgreSqlSemaphoreOptions> configureOptions,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        services.Configure(configureOptions);
+
+        if (configureSemaphoreOptions != null)
+            services.Configure(configureSemaphoreOptions);
+
+        return services.AddSemaphore<PostgreSqlSemaphoreProvider>();
+    }
+
+    /// <summary>
+    /// Adds PostgreSQL semaphore services to the dependency injection container with connection string.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The PostgreSQL connection string.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddPostgreSqlSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddPostgreSqlSemaphore(
+            options => options.ConnectionString = connectionString,
+            configureSemaphoreOptions);
+    }
+
+    /// <summary>
+    /// Adds PostgreSQL semaphore services to the dependency injection container with connection string and table configuration.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The PostgreSQL connection string.</param>
+    /// <param name="tableName">The name of the semaphore table.</param>
+    /// <param name="schemaName">The schema name for the semaphore table.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddPostgreSqlSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        string tableName,
+        string schemaName = "public",
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddPostgreSqlSemaphore(
+            options =>
+            {
+                options.ConnectionString = connectionString;
+                options.TableName = tableName;
+                options.SchemaName = schemaName;
+            },
+            configureSemaphoreOptions);
     }
 }

--- a/src/Providers/MultiLock.PostgreSQL/PostgreSqlSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.PostgreSQL/PostgreSqlSemaphoreOptions.cs
@@ -1,0 +1,59 @@
+﻿namespace MultiLock.PostgreSQL;
+
+/// <summary>
+/// Configuration options for the PostgreSQL semaphore provider.
+/// </summary>
+public sealed class PostgreSqlSemaphoreOptions
+{
+    /// <summary>
+    /// Gets or sets the PostgreSQL connection string.
+    /// </summary>
+    public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the table used for semaphore holders.
+    /// Default is "semaphore_holders".
+    /// </summary>
+    public string TableName { get; set; } = "semaphore_holders";
+
+    /// <summary>
+    /// Gets or sets the schema name for the semaphore table.
+    /// Default is "public".
+    /// </summary>
+    public string SchemaName { get; set; } = "public";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically create the semaphore table if it doesn't exist.
+    /// Default is true.
+    /// </summary>
+    public bool AutoCreateTable { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the command timeout in seconds for PostgreSQL operations.
+    /// Default is 30 seconds.
+    /// </summary>
+    public int CommandTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Validates the configuration options.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when configuration is invalid.</exception>
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(ConnectionString))
+            throw new ArgumentException("Connection string cannot be null or empty.", nameof(ConnectionString));
+
+        if (string.IsNullOrWhiteSpace(TableName))
+            throw new ArgumentException("Table name cannot be null or empty.", nameof(TableName));
+
+        if (string.IsNullOrWhiteSpace(SchemaName))
+            throw new ArgumentException("Schema name cannot be null or empty.", nameof(SchemaName));
+
+        ParameterValidation.ValidateSqlIdentifier(TableName, nameof(TableName));
+        ParameterValidation.ValidateSqlIdentifier(SchemaName, nameof(SchemaName));
+
+        if (CommandTimeoutSeconds <= 0)
+            throw new ArgumentException("Command timeout must be positive.", nameof(CommandTimeoutSeconds));
+    }
+}
+

--- a/src/Providers/MultiLock.PostgreSQL/PostgreSqlSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.PostgreSQL/PostgreSqlSemaphoreOptions.cs
@@ -49,8 +49,11 @@ public sealed class PostgreSqlSemaphoreOptions
         if (string.IsNullOrWhiteSpace(SchemaName))
             throw new ArgumentException("Schema name cannot be null or empty.", nameof(SchemaName));
 
-        ParameterValidation.ValidateSqlIdentifier(TableName, nameof(TableName));
-        ParameterValidation.ValidateSqlIdentifier(SchemaName, nameof(SchemaName));
+        // PostgreSQL truncates identifiers to 63 bytes (NAMEDATALEN - 1), so enforce that limit
+        // to prevent distinct long names from colliding after server-side truncation.
+        const int postgreSqlMaxIdentifierLength = 63;
+        ParameterValidation.ValidateSqlIdentifier(TableName, nameof(TableName), postgreSqlMaxIdentifierLength);
+        ParameterValidation.ValidateSqlIdentifier(SchemaName, nameof(SchemaName), postgreSqlMaxIdentifierLength);
 
         if (CommandTimeoutSeconds <= 0)
             throw new ArgumentException("Command timeout must be positive.", nameof(CommandTimeoutSeconds));

--- a/src/Providers/MultiLock.PostgreSQL/PostgreSqlSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.PostgreSQL/PostgreSqlSemaphoreProvider.cs
@@ -1,0 +1,526 @@
+﻿using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.Exceptions;
+using Npgsql;
+
+namespace MultiLock.PostgreSQL;
+
+/// <summary>
+/// PostgreSQL implementation of the semaphore provider.
+/// </summary>
+public sealed class PostgreSqlSemaphoreProvider : ISemaphoreProvider
+{
+    private readonly PostgreSqlSemaphoreOptions options;
+    private readonly ILogger<PostgreSqlSemaphoreProvider> logger;
+    private readonly SemaphoreSlim initializationLock = new(1, 1);
+    private volatile bool isInitialized;
+    private volatile bool isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgreSqlSemaphoreProvider"/> class.
+    /// </summary>
+    /// <param name="options">The PostgreSQL options.</param>
+    /// <param name="logger">The logger.</param>
+    public PostgreSqlSemaphoreProvider(
+        IOptions<PostgreSqlSemaphoreOptions> options,
+        ILogger<PostgreSqlSemaphoreProvider> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+
+        this.options.Validate();
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAcquireAsync(
+        string semaphoreName,
+        string holderId,
+        int maxCount,
+        IReadOnlyDictionary<string, string> metadata,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMaxCount(maxCount);
+        ParameterValidation.ValidateMetadata(metadata);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            string metadataJson = JsonSerializer.Serialize(metadata);
+            DateTimeOffset expiryTime = now.Subtract(slotTimeout);
+
+            // ReadCommitted is sufficient because we use a per-semaphore advisory lock below to
+            // serialize all concurrent acquisitions for the same semaphore name. SERIALIZABLE +
+            // FOR UPDATE fails when the table is empty because there are no rows to lock, causing
+            // all concurrent transactions to see count=0 and then receive serialization failures.
+            await using var transaction = await connection.BeginTransactionAsync(
+                System.Data.IsolationLevel.ReadCommitted, cancellationToken);
+
+            try
+            {
+                // Acquire an exclusive advisory lock scoped to this transaction.
+                // hashtext() maps the semaphore name to a stable int4 key; the advisory lock
+                // serialises all concurrent callers for the same semaphore without requiring any
+                // existing rows in the table (unlike FOR UPDATE).
+                string advisoryLockSql = "SELECT pg_advisory_xact_lock(hashtext(@SemaphoreName))";
+                await using (var lockCommand = new NpgsqlCommand(advisoryLockSql, connection, transaction))
+                {
+                    lockCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    lockCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    await lockCommand.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                // Clean up expired slots
+                string cleanupSql = $@"
+                    DELETE FROM {options.SchemaName}.{options.TableName}
+                    WHERE semaphore_name = @SemaphoreName AND last_heartbeat < @ExpiryTime";
+
+                await using (var cleanupCommand = new NpgsqlCommand(cleanupSql, connection, transaction))
+                {
+                    cleanupCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    cleanupCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    cleanupCommand.Parameters.AddWithValue("@ExpiryTime", expiryTime);
+                    await cleanupCommand.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                // Check if holder already has a slot (renew it)
+                string checkExistingSql = $@"
+                    UPDATE {options.SchemaName}.{options.TableName}
+                    SET last_heartbeat = @Now, metadata = @Metadata::jsonb
+                    WHERE semaphore_name = @SemaphoreName AND holder_id = @HolderId
+                    RETURNING 1";
+
+                await using (var checkCommand = new NpgsqlCommand(checkExistingSql, connection, transaction))
+                {
+                    checkCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    checkCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    checkCommand.Parameters.AddWithValue("@HolderId", holderId);
+                    checkCommand.Parameters.AddWithValue("@Now", now);
+                    checkCommand.Parameters.AddWithValue("@Metadata", metadataJson);
+
+                    object? existingResult = await checkCommand.ExecuteScalarAsync(cancellationToken);
+                    if (existingResult != null)
+                    {
+                        await transaction.CommitAsync(cancellationToken);
+                        logger.LogDebug("Renewed existing slot for holder {HolderId} in semaphore {SemaphoreName}",
+                            holderId, semaphoreName);
+                        return true;
+                    }
+                }
+
+                // Count current holders (advisory lock guarantees no concurrent inserts)
+                string countSql = $@"
+                    SELECT COUNT(*) FROM {options.SchemaName}.{options.TableName}
+                    WHERE semaphore_name = @SemaphoreName";
+
+                int currentCount;
+                await using (var countCommand = new NpgsqlCommand(countSql, connection, transaction))
+                {
+                    countCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    countCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    currentCount = Convert.ToInt32(await countCommand.ExecuteScalarAsync(cancellationToken));
+                }
+
+                if (currentCount >= maxCount)
+                {
+                    await transaction.RollbackAsync(cancellationToken);
+                    logger.LogDebug("Semaphore {SemaphoreName} is full ({CurrentCount}/{MaxCount})",
+                        semaphoreName, currentCount, maxCount);
+                    return false;
+                }
+
+                // Insert new holder
+                string insertSql = $@"
+                    INSERT INTO {options.SchemaName}.{options.TableName}
+                        (semaphore_name, holder_id, acquired_at, last_heartbeat, metadata)
+                    VALUES (@SemaphoreName, @HolderId, @Now, @Now, @Metadata::jsonb)";
+
+                await using (var insertCommand = new NpgsqlCommand(insertSql, connection, transaction))
+                {
+                    insertCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    insertCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    insertCommand.Parameters.AddWithValue("@HolderId", holderId);
+                    insertCommand.Parameters.AddWithValue("@Now", now);
+                    insertCommand.Parameters.AddWithValue("@Metadata", metadataJson);
+                    await insertCommand.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                await transaction.CommitAsync(cancellationToken);
+                logger.LogInformation("Acquired slot for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+                return true;
+            }
+            catch
+            {
+                // Only rollback if the transaction is still active
+                if (transaction.Connection != null)
+                    await transaction.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is not SemaphoreException)
+        {
+            logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to acquire semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            string sql = $@"
+                DELETE FROM {options.SchemaName}.{options.TableName}
+                WHERE semaphore_name = @SemaphoreName AND holder_id = @HolderId";
+
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+            command.Parameters.AddWithValue("@HolderId", holderId);
+
+            int rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
+
+            if (rowsAffected > 0)
+                logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+            else
+                logger.LogWarning("No slot found to release for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to release semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateHeartbeatAsync(
+        string semaphoreName,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMetadata(metadata);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            string metadataJson = JsonSerializer.Serialize(metadata);
+
+            string sql = $@"
+                UPDATE {options.SchemaName}.{options.TableName}
+                SET last_heartbeat = @Now, metadata = @Metadata::jsonb
+                WHERE semaphore_name = @SemaphoreName AND holder_id = @HolderId";
+
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+            command.Parameters.AddWithValue("@HolderId", holderId);
+            command.Parameters.AddWithValue("@Now", now);
+            command.Parameters.AddWithValue("@Metadata", metadataJson);
+
+            int rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
+            bool updated = rowsAffected > 0;
+
+            logger.LogDebug("Updated heartbeat for holder {HolderId} in semaphore {SemaphoreName}: {Updated}",
+                holderId, semaphoreName, updated);
+
+            return updated;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to update heartbeat", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetCurrentCountAsync(
+        string semaphoreName,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            DateTimeOffset expiryTime = DateTimeOffset.UtcNow.Subtract(slotTimeout);
+
+            string sql = $@"
+                SELECT COUNT(*) FROM {options.SchemaName}.{options.TableName}
+                WHERE semaphore_name = @SemaphoreName AND last_heartbeat >= @ExpiryTime";
+
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+            command.Parameters.AddWithValue("@ExpiryTime", expiryTime);
+
+            object? result = await command.ExecuteScalarAsync(cancellationToken);
+            return Convert.ToInt32(result);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting current count for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get current count", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SemaphoreHolder>> GetHoldersAsync(
+        string semaphoreName,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            string sql = $@"
+                SELECT holder_id, acquired_at, last_heartbeat, metadata
+                FROM {options.SchemaName}.{options.TableName}
+                WHERE semaphore_name = @SemaphoreName
+                ORDER BY acquired_at";
+
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+
+            await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            var holders = new List<SemaphoreHolder>();
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                string holderId = reader.GetString(reader.GetOrdinal("holder_id"));
+                DateTimeOffset acquiredAt = reader.GetFieldValue<DateTimeOffset>(reader.GetOrdinal("acquired_at"));
+                DateTimeOffset lastHeartbeat = reader.GetFieldValue<DateTimeOffset>(reader.GetOrdinal("last_heartbeat"));
+                string metadataJson = reader.GetString(reader.GetOrdinal("metadata"));
+
+                Dictionary<string, string> metadata = JsonSerializer.Deserialize<Dictionary<string, string>>(metadataJson)
+                                                      ?? new Dictionary<string, string>();
+
+                holders.Add(new SemaphoreHolder(holderId, acquiredAt, lastHeartbeat, metadata));
+            }
+
+            return holders;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get holders", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsHoldingAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            string sql = $@"
+                SELECT COUNT(1) FROM {options.SchemaName}.{options.TableName}
+                WHERE semaphore_name = @SemaphoreName AND holder_id = @HolderId";
+
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+            command.Parameters.AddWithValue("@HolderId", holderId);
+
+            object? result = await command.ExecuteScalarAsync(cancellationToken);
+            return Convert.ToInt32(result) > 0;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error checking if holder {HolderId} is holding semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to check holding status", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
+    {
+        if (isDisposed)
+            return false;
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = new NpgsqlCommand("SELECT 1", connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+
+            await command.ExecuteScalarAsync(cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Health check failed for PostgreSQL semaphore provider");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (isDisposed) return;
+        isDisposed = true;
+        initializationLock.Dispose();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (!isDisposed) return;
+        throw new ObjectDisposedException(nameof(PostgreSqlSemaphoreProvider));
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (isInitialized)
+            return;
+
+        await initializationLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (isInitialized)
+                return;
+
+            if (options.AutoCreateTable)
+                await CreateTableIfNotExistsAsync(cancellationToken);
+
+            isInitialized = true;
+        }
+        finally
+        {
+            initializationLock.Release();
+        }
+    }
+
+    private async Task CreateTableIfNotExistsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = new NpgsqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            // Create schema if it doesn't exist
+            string createSchemaSql = $@"CREATE SCHEMA IF NOT EXISTS {options.SchemaName};";
+
+            await using var schemaCommand = new NpgsqlCommand(createSchemaSql, connection);
+            schemaCommand.CommandTimeout = options.CommandTimeoutSeconds;
+            await schemaCommand.ExecuteNonQueryAsync(cancellationToken);
+
+            // Create table if it doesn't exist
+            string sql = $@"
+                CREATE TABLE IF NOT EXISTS {options.SchemaName}.{options.TableName} (
+                    semaphore_name VARCHAR(255) NOT NULL,
+                    holder_id VARCHAR(255) NOT NULL,
+                    acquired_at TIMESTAMPTZ NOT NULL,
+                    last_heartbeat TIMESTAMPTZ NOT NULL,
+                    metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+                    PRIMARY KEY (semaphore_name, holder_id)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_{(options.TableName.Length > 56 ? options.TableName[..56] : options.TableName)}_hb
+                ON {options.SchemaName}.{options.TableName} (semaphore_name, last_heartbeat);";
+
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+
+            logger.LogInformation("Semaphore table {Schema}.{Table} created or verified",
+                options.SchemaName, options.TableName);
+        }
+        catch (PostgresException ex) when (ex.SqlState is "42P07" or "42710" or "23505")
+        {
+            // 42P07: relation already exists - table was created concurrently
+            // 42710: type already exists - another process created the table concurrently
+            // 23505: duplicate key - another process created the table concurrently
+            // All are safe to ignore since the table now exists
+            logger.LogDebug("Semaphore table {Schema}.{Table} was created by another process",
+                options.SchemaName, options.TableName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error creating semaphore table {Schema}.{Table}",
+                options.SchemaName, options.TableName);
+            throw new SemaphoreProviderException("Failed to create semaphore table", ex);
+        }
+    }
+}

--- a/src/Providers/MultiLock.PostgreSQL/PostgreSqlSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.PostgreSQL/PostgreSqlSemaphoreProvider.cs
@@ -67,11 +67,19 @@ public sealed class PostgreSqlSemaphoreProvider : ISemaphoreProvider
 
             try
             {
-                // Acquire an exclusive advisory lock scoped to this transaction.
-                // hashtext() maps the semaphore name to a stable int4 key; the advisory lock
+                // Acquire an exclusive advisory lock scoped to this transaction. The advisory lock
                 // serialises all concurrent callers for the same semaphore without requiring any
                 // existing rows in the table (unlike FOR UPDATE).
-                string advisoryLockSql = "SELECT pg_advisory_xact_lock(hashtext(@SemaphoreName))";
+                //
+                // The lock key is the first 64 bits of md5(name) rather than hashtext(name):
+                //   - hashtext() returns a 32-bit value, so distinct semaphore names collide at a
+                //     non-trivial rate (birthday bound ~2^16 names); a collision serialises two
+                //     unrelated semaphores against each other (a liveness/throughput hit).
+                //   - hashtext() is explicitly documented as not stable across PostgreSQL versions,
+                //     whereas md5() is stable, so a mixed-version cluster stays consistent.
+                // A 64-bit key makes collisions negligible and the mapping deterministic.
+                string advisoryLockSql =
+                    "SELECT pg_advisory_xact_lock(('x' || substr(md5(@SemaphoreName), 1, 16))::bit(64)::bigint)";
                 await using (var lockCommand = new NpgsqlCommand(advisoryLockSql, connection, transaction))
                 {
                     lockCommand.CommandTimeout = options.CommandTimeoutSeconds;

--- a/src/Providers/MultiLock.Redis/MultiLock.Redis.csproj
+++ b/src/Providers/MultiLock.Redis/MultiLock.Redis.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <PackageId>MultiLock.Redis</PackageId>
-    <Description>Redis provider for MultiLock - Leader Election framework for distributed systems. This package includes the core MultiLock framework.</Description>
-    <PackageTags>leader-election;distributed-systems;high-availability;failover;redis;cache;in-memory-database</PackageTags>
+    <Description>Redis provider for MultiLock - Leader Election and Distributed Semaphores framework for distributed systems. This package includes the core MultiLock framework.</Description>
+    <PackageTags>leader-election;distributed-systems;high-availability;failover;semaphore;rate-limiting;redis;cache;in-memory-database</PackageTags>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Providers/MultiLock.Redis/RedisSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.Redis/RedisSemaphoreOptions.cs
@@ -1,0 +1,41 @@
+﻿namespace MultiLock.Redis;
+
+/// <summary>
+/// Configuration options for the Redis semaphore provider.
+/// </summary>
+public sealed class RedisSemaphoreOptions
+{
+    /// <summary>
+    /// Gets or sets the Redis connection string.
+    /// </summary>
+    public string ConnectionString { get; set; } = "localhost:6379";
+
+    /// <summary>
+    /// Gets or sets the key prefix for semaphore keys.
+    /// Default is "semaphore".
+    /// </summary>
+    public string KeyPrefix { get; set; } = "semaphore";
+
+    /// <summary>
+    /// Gets or sets the database number to use.
+    /// Default is 0.
+    /// </summary>
+    public int Database { get; set; } = 0;
+
+    /// <summary>
+    /// Validates the configuration options.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when configuration is invalid.</exception>
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(ConnectionString))
+            throw new ArgumentException("Connection string cannot be null or empty.", nameof(ConnectionString));
+
+        if (string.IsNullOrWhiteSpace(KeyPrefix))
+            throw new ArgumentException("Key prefix cannot be null or empty.", nameof(KeyPrefix));
+
+        if (Database < 0)
+            throw new ArgumentException("Database number cannot be negative.", nameof(Database));
+    }
+}
+

--- a/src/Providers/MultiLock.Redis/RedisSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.Redis/RedisSemaphoreOptions.cs
@@ -1,9 +1,11 @@
-﻿namespace MultiLock.Redis;
+﻿using System.Text.RegularExpressions;
+
+namespace MultiLock.Redis;
 
 /// <summary>
 /// Configuration options for the Redis semaphore provider.
 /// </summary>
-public sealed class RedisSemaphoreOptions
+public sealed partial class RedisSemaphoreOptions
 {
     /// <summary>
     /// Gets or sets the Redis connection string.
@@ -34,8 +36,18 @@ public sealed class RedisSemaphoreOptions
         if (string.IsNullOrWhiteSpace(KeyPrefix))
             throw new ArgumentException("Key prefix cannot be null or empty.", nameof(KeyPrefix));
 
+        // Restrict the key prefix to safe characters (alphanumeric plus ':', '-', '_') for
+        // consistency with the other providers and to avoid surprising Redis key patterns.
+        if (!KeyPrefixRegex().IsMatch(KeyPrefix))
+            throw new ArgumentException(
+                "Key prefix may contain only alphanumeric characters, colons, hyphens, and underscores.",
+                nameof(KeyPrefix));
+
         if (Database < 0)
             throw new ArgumentException("Database number cannot be negative.", nameof(Database));
     }
+
+    [GeneratedRegex(@"^[a-zA-Z0-9:_-]+$", RegexOptions.Compiled)]
+    private static partial Regex KeyPrefixRegex();
 }
 

--- a/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
@@ -1,0 +1,393 @@
+﻿using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.Exceptions;
+using StackExchange.Redis;
+
+namespace MultiLock.Redis;
+
+/// <summary>
+/// Redis implementation of the semaphore provider.
+/// Uses Redis sorted sets (ZSET) for semaphore implementation with Lua scripts for atomic operations.
+/// </summary>
+public sealed class RedisSemaphoreProvider : ISemaphoreProvider
+{
+    private readonly RedisSemaphoreOptions options;
+    private readonly ILogger<RedisSemaphoreProvider> logger;
+    private readonly Lazy<ConnectionMultiplexer> connectionMultiplexer;
+    private volatile bool isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisSemaphoreProvider"/> class.
+    /// </summary>
+    /// <param name="options">The Redis options.</param>
+    /// <param name="logger">The logger.</param>
+    public RedisSemaphoreProvider(
+        IOptions<RedisSemaphoreOptions> options,
+        ILogger<RedisSemaphoreProvider> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+
+        this.options.Validate();
+
+        connectionMultiplexer = new Lazy<ConnectionMultiplexer>(() =>
+            ConnectionMultiplexer.Connect(this.options.ConnectionString));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAcquireAsync(
+        string semaphoreName,
+        string holderId,
+        int maxCount,
+        IReadOnlyDictionary<string, string> metadata,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMaxCount(maxCount);
+        ParameterValidation.ValidateMetadata(metadata);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+
+        try
+        {
+            IDatabase database = GetDatabase();
+            string holdersKey = GetHoldersKey(semaphoreName);
+            string dataKey = GetDataKey(semaphoreName);
+            double now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            double expiryTime = now - slotTimeout.TotalMilliseconds;
+
+            // Lua script for atomic acquire operation:
+            // 1. Remove expired holders
+            // 2. Check if holder already exists (renew)
+            // 3. Check if there's room for new holder
+            // 4. Add holder if room available
+            const string script = @"
+                -- Collect and remove expired holders, then also purge their hash data
+                local expired = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+                redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+                if #expired > 0 then
+                    redis.call('HDEL', KEYS[2], unpack(expired))
+                end
+
+                -- Check if holder already exists
+                local existingScore = redis.call('ZSCORE', KEYS[1], ARGV[2])
+                if existingScore then
+                    -- Renew heartbeat score; preserve original AcquiredAt from stored data
+                    redis.call('ZADD', KEYS[1], ARGV[3], ARGV[2])
+                    local existingJson = redis.call('HGET', KEYS[2], ARGV[2])
+                    if existingJson then
+                        local existing = cjson.decode(existingJson)
+                        local newData  = cjson.decode(ARGV[4])
+                        newData['AcquiredAt'] = existing['AcquiredAt']
+                        redis.call('HSET', KEYS[2], ARGV[2], cjson.encode(newData))
+                    else
+                        redis.call('HSET', KEYS[2], ARGV[2], ARGV[4])
+                    end
+                    return 1
+                end
+
+                -- Check current count
+                local currentCount = redis.call('ZCARD', KEYS[1])
+                if currentCount >= tonumber(ARGV[5]) then
+                    return 0
+                end
+
+                -- Add new holder
+                redis.call('ZADD', KEYS[1], ARGV[3], ARGV[2])
+                redis.call('HSET', KEYS[2], ARGV[2], ARGV[4])
+                return 1";
+
+            var holderData = new HolderData
+            {
+                HolderId = holderId,
+                AcquiredAt = DateTimeOffset.UtcNow,
+                Metadata = new Dictionary<string, string>(metadata)
+            };
+            string holderDataJson = JsonSerializer.Serialize(holderData);
+
+            RedisResult result = await database.ScriptEvaluateAsync(script,
+                [holdersKey, dataKey],
+                [expiryTime, holderId, now, holderDataJson, maxCount]);
+
+            bool acquired = (int)result == 1;
+
+            if (acquired)
+                logger.LogInformation("Acquired slot for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+            else
+                logger.LogDebug("Failed to acquire slot for holder {HolderId} in semaphore {SemaphoreName} - full",
+                    holderId, semaphoreName);
+
+            return acquired;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to acquire semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+
+        try
+        {
+            IDatabase database = GetDatabase();
+            string holdersKey = GetHoldersKey(semaphoreName);
+            string dataKey = GetDataKey(semaphoreName);
+
+            // Lua script to atomically remove holder from both keys
+            const string script = @"
+                redis.call('ZREM', KEYS[1], ARGV[1])
+                redis.call('HDEL', KEYS[2], ARGV[1])
+                return 1";
+
+            await database.ScriptEvaluateAsync(script, [holdersKey, dataKey], [holderId]);
+
+            logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to release semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateHeartbeatAsync(
+        string semaphoreName,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMetadata(metadata);
+
+        try
+        {
+            IDatabase database = GetDatabase();
+            string holdersKey = GetHoldersKey(semaphoreName);
+            string dataKey = GetDataKey(semaphoreName);
+            double now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+            // Lua script to update heartbeat only if holder exists
+            const string script = @"
+                local existingScore = redis.call('ZSCORE', KEYS[1], ARGV[1])
+                if existingScore then
+                    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
+                    local existingData = redis.call('HGET', KEYS[2], ARGV[1])
+                    if existingData then
+                        local data = cjson.decode(existingData)
+                        data.Metadata = cjson.decode(ARGV[3])
+                        redis.call('HSET', KEYS[2], ARGV[1], cjson.encode(data))
+                    end
+                    return 1
+                end
+                return 0";
+
+            string metadataJson = JsonSerializer.Serialize(metadata);
+
+            RedisResult result = await database.ScriptEvaluateAsync(script,
+                [holdersKey, dataKey],
+                [holderId, now, metadataJson]);
+
+            bool success = (int)result == 1;
+
+            if (success)
+                logger.LogDebug("Updated heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+            else
+                logger.LogWarning("Heartbeat update failed for holder {HolderId} in semaphore {SemaphoreName} - not a holder",
+                    holderId, semaphoreName);
+
+            return success;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to update heartbeat", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetCurrentCountAsync(
+        string semaphoreName,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+
+        try
+        {
+            IDatabase database = GetDatabase();
+            string holdersKey = GetHoldersKey(semaphoreName);
+
+            // Only count members whose score (last heartbeat as Unix milliseconds) is within the slot timeout.
+            double minScore = DateTimeOffset.UtcNow.Subtract(slotTimeout).ToUnixTimeMilliseconds();
+            long count = await database.SortedSetLengthAsync(holdersKey, minScore, double.PositiveInfinity);
+            return (int)count;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting current count for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get current count", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SemaphoreHolder>> GetHoldersAsync(
+        string semaphoreName,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+
+        try
+        {
+            IDatabase database = GetDatabase();
+            string holdersKey = GetHoldersKey(semaphoreName);
+            string dataKey = GetDataKey(semaphoreName);
+
+            // Get all holders with their scores (heartbeat timestamps)
+            SortedSetEntry[] entries = await database.SortedSetRangeByRankWithScoresAsync(holdersKey);
+
+            if (entries.Length == 0)
+                return [];
+
+            // Batch-fetch all holder data in a single round trip instead of N individual calls.
+            RedisValue[] holderIds = Array.ConvertAll(entries, e => e.Element);
+            RedisValue[] dataValues = await database.HashGetAsync(dataKey, holderIds);
+
+            var holders = new List<SemaphoreHolder>(entries.Length);
+            for (int i = 0; i < entries.Length; i++)
+            {
+                string holderId = entries[i].Element!;
+                DateTimeOffset lastHeartbeat = DateTimeOffset.FromUnixTimeMilliseconds((long)entries[i].Score);
+                DateTimeOffset acquiredAt = lastHeartbeat;
+                IReadOnlyDictionary<string, string> metadata = new Dictionary<string, string>();
+
+                if (dataValues[i].HasValue)
+                {
+                    HolderData? holderData = JsonSerializer.Deserialize<HolderData>((string)dataValues[i]!);
+                    if (holderData != null)
+                    {
+                        acquiredAt = holderData.AcquiredAt;
+                        metadata = holderData.Metadata;
+                    }
+                }
+
+                holders.Add(new SemaphoreHolder(holderId, acquiredAt, lastHeartbeat, metadata));
+            }
+
+            return holders;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get holders", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsHoldingAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+
+        try
+        {
+            IDatabase database = GetDatabase();
+            string holdersKey = GetHoldersKey(semaphoreName);
+
+            double? score = await database.SortedSetScoreAsync(holdersKey, holderId);
+            return score.HasValue;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error checking if holder {HolderId} is holding semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to check holding status", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
+    {
+        if (isDisposed)
+            return false;
+
+        try
+        {
+            IDatabase database = GetDatabase();
+            await database.PingAsync();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Health check failed for Redis semaphore provider");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (isDisposed) return;
+        isDisposed = true;
+
+        if (connectionMultiplexer.IsValueCreated)
+            connectionMultiplexer.Value.Dispose();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (!isDisposed) return;
+        throw new ObjectDisposedException(nameof(RedisSemaphoreProvider));
+    }
+
+    private IDatabase GetDatabase()
+    {
+        return connectionMultiplexer.Value.GetDatabase(options.Database);
+    }
+
+    private string GetHoldersKey(string semaphoreName)
+    {
+        return $"{options.KeyPrefix}:{semaphoreName}:holders";
+    }
+
+    private string GetDataKey(string semaphoreName)
+    {
+        return $"{options.KeyPrefix}:{semaphoreName}:data";
+    }
+
+    /// <summary>
+    /// Internal class to represent holder data stored in Redis.
+    /// </summary>
+    private sealed class HolderData
+    {
+        public string HolderId { get; set; } = string.Empty;
+        public DateTimeOffset AcquiredAt { get; set; }
+        public Dictionary<string, string> Metadata { get; set; } = new();
+    }
+}

--- a/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
@@ -376,14 +376,18 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
         return connectionMultiplexer.Value.GetDatabase(options.Database);
     }
 
+    // The "{prefix:name}" hash tag forces both of a semaphore's keys into the same Redis Cluster
+    // hash slot. Without it, the holders and data keys hash to different slots and every multi-key
+    // Lua script (acquire/release/heartbeat) fails with CROSSSLOT on clustered deployments.
+    // Harmless on standalone Redis, where the braces are just part of the key name.
     private string GetHoldersKey(string semaphoreName)
     {
-        return $"{options.KeyPrefix}:{semaphoreName}:holders";
+        return $"{{{options.KeyPrefix}:{semaphoreName}}}:holders";
     }
 
     private string GetDataKey(string semaphoreName)
     {
-        return $"{options.KeyPrefix}:{semaphoreName}:data";
+        return $"{{{options.KeyPrefix}:{semaphoreName}}}:data";
     }
 
     /// <summary>

--- a/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
@@ -123,7 +123,7 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
 
             return acquired;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
@@ -158,7 +158,7 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
             logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
@@ -217,7 +217,7 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
 
             return success;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
                 holderId, semaphoreName);
@@ -244,7 +244,7 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
             long count = await database.SortedSetLengthAsync(holdersKey, minScore, double.PositiveInfinity);
             return (int)count;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error getting current count for semaphore {SemaphoreName}", semaphoreName);
             throw new SemaphoreProviderException("Failed to get current count", ex);
@@ -303,7 +303,7 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
 
             return holders;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
             throw new SemaphoreProviderException("Failed to get holders", ex);
@@ -328,7 +328,7 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
             double? score = await database.SortedSetScoreAsync(holdersKey, holderId);
             return score.HasValue;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error checking if holder {HolderId} is holding semaphore {SemaphoreName}",
                 holderId, semaphoreName);
@@ -348,7 +348,7 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
             await database.PingAsync();
             return true;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogWarning(ex, "Health check failed for Redis semaphore provider");
             return false;

--- a/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
@@ -291,6 +291,11 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
                         acquiredAt = holderData.AcquiredAt;
                         metadata = holderData.Metadata;
                     }
+                    else
+                    {
+                        logger.LogWarning("Holder data for {HolderId} in semaphore {SemaphoreName} could not be deserialized; falling back to heartbeat timestamp",
+                            holderId, semaphoreName);
+                    }
                 }
 
                 holders.Add(new SemaphoreHolder(holderId, acquiredAt, lastHeartbeat, metadata));

--- a/src/Providers/MultiLock.Redis/RedisServiceCollectionExtensions.cs
+++ b/src/Providers/MultiLock.Redis/RedisServiceCollectionExtensions.cs
@@ -3,10 +3,11 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MultiLock.Redis;
 
 /// <summary>
-/// Extension methods for configuring Redis leader election services.
+/// Extension methods for configuring Redis leader election and semaphore services.
 /// </summary>
 public static class RedisServiceCollectionExtensions
 {
+    // Leader Election Methods
     /// <summary>
     /// Adds Redis leader election services to the dependency injection container.
     /// </summary>
@@ -20,7 +21,7 @@ public static class RedisServiceCollectionExtensions
         Action<LeaderElectionOptions>? configureLeaderElectionOptions = null)
     {
         services.Configure(configureOptions);
-        
+
         if (configureLeaderElectionOptions != null)
         {
             services.Configure(configureLeaderElectionOptions);
@@ -67,5 +68,67 @@ public static class RedisServiceCollectionExtensions
                 options.Database = database;
             },
             configureLeaderElectionOptions);
+    }
+
+    // Semaphore Methods
+
+    /// <summary>
+    /// Adds Redis semaphore services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the Redis options.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddRedisSemaphore(
+        this IServiceCollection services,
+        Action<RedisSemaphoreOptions> configureOptions,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        services.Configure(configureOptions);
+
+        if (configureSemaphoreOptions != null)
+            services.Configure(configureSemaphoreOptions);
+
+        return services.AddSemaphore<RedisSemaphoreProvider>();
+    }
+
+    /// <summary>
+    /// Adds Redis semaphore services to the dependency injection container with connection string.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The Redis connection string.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddRedisSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddRedisSemaphore(
+            options => options.ConnectionString = connectionString,
+            configureSemaphoreOptions);
+    }
+
+    /// <summary>
+    /// Adds Redis semaphore services to the dependency injection container with connection string and database.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The Redis connection string.</param>
+    /// <param name="database">The Redis database number.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddRedisSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        int database,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddRedisSemaphore(
+            options =>
+            {
+                options.ConnectionString = connectionString;
+                options.Database = database;
+            },
+            configureSemaphoreOptions);
     }
 }

--- a/src/Providers/MultiLock.SqlServer/MultiLock.SqlServer.csproj
+++ b/src/Providers/MultiLock.SqlServer/MultiLock.SqlServer.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <PackageId>MultiLock.SqlServer</PackageId>
-    <Description>SQL Server provider for MultiLock - Leader Election framework for distributed systems. This package includes the core MultiLock framework.</Description>
-    <PackageTags>leader-election;distributed-systems;high-availability;failover;sql-server;mssql;database</PackageTags>
+    <Description>SQL Server provider for MultiLock - Leader Election and Distributed Semaphores framework for distributed systems. This package includes the core MultiLock framework.</Description>
+    <PackageTags>leader-election;distributed-systems;high-availability;failover;semaphore;rate-limiting;sql-server;mssql;database</PackageTags>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Providers/MultiLock.SqlServer/SqlServerSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.SqlServer/SqlServerSemaphoreOptions.cs
@@ -1,0 +1,59 @@
+﻿namespace MultiLock.SqlServer;
+
+/// <summary>
+/// Configuration options for the SQL Server semaphore provider.
+/// </summary>
+public sealed class SqlServerSemaphoreOptions
+{
+    /// <summary>
+    /// Gets or sets the SQL Server connection string.
+    /// </summary>
+    public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the table used for semaphore holders.
+    /// Default is "SemaphoreHolders".
+    /// </summary>
+    public string TableName { get; set; } = "SemaphoreHolders";
+
+    /// <summary>
+    /// Gets or sets the schema name for the semaphore table.
+    /// Default is "dbo".
+    /// </summary>
+    public string SchemaName { get; set; } = "dbo";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically create the semaphore table if it doesn't exist.
+    /// Default is true.
+    /// </summary>
+    public bool AutoCreateTable { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the command timeout in seconds for SQL operations.
+    /// Default is 30 seconds.
+    /// </summary>
+    public int CommandTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Validates the configuration options.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when configuration is invalid.</exception>
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(ConnectionString))
+            throw new ArgumentException("Connection string cannot be null or empty.", nameof(ConnectionString));
+
+        if (string.IsNullOrWhiteSpace(TableName))
+            throw new ArgumentException("Table name cannot be null or empty.", nameof(TableName));
+
+        if (string.IsNullOrWhiteSpace(SchemaName))
+            throw new ArgumentException("Schema name cannot be null or empty.", nameof(SchemaName));
+
+        ParameterValidation.ValidateSqlIdentifier(TableName, nameof(TableName));
+        ParameterValidation.ValidateSqlIdentifier(SchemaName, nameof(SchemaName));
+
+        if (CommandTimeoutSeconds <= 0)
+            throw new ArgumentException("Command timeout must be positive.", nameof(CommandTimeoutSeconds));
+    }
+}
+

--- a/src/Providers/MultiLock.SqlServer/SqlServerSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.SqlServer/SqlServerSemaphoreProvider.cs
@@ -1,0 +1,508 @@
+﻿using System.Text.Json;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.Exceptions;
+
+namespace MultiLock.SqlServer;
+
+/// <summary>
+/// SQL Server implementation of the semaphore provider.
+/// </summary>
+public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
+{
+    private readonly SqlServerSemaphoreOptions options;
+    private readonly ILogger<SqlServerSemaphoreProvider> logger;
+    private readonly SemaphoreSlim initializationLock = new(1, 1);
+    private volatile bool isInitialized;
+    private volatile bool isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerSemaphoreProvider"/> class.
+    /// </summary>
+    /// <param name="options">The SQL Server options.</param>
+    /// <param name="logger">The logger.</param>
+    public SqlServerSemaphoreProvider(
+        IOptions<SqlServerSemaphoreOptions> options,
+        ILogger<SqlServerSemaphoreProvider> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+
+        this.options.Validate();
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAcquireAsync(
+        string semaphoreName,
+        string holderId,
+        int maxCount,
+        IReadOnlyDictionary<string, string> metadata,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMaxCount(maxCount);
+        ParameterValidation.ValidateMetadata(metadata);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new SqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            string metadataJson = JsonSerializer.Serialize(metadata);
+            DateTimeOffset expiryTime = now.Subtract(slotTimeout);
+
+            // ReadCommitted is sufficient because sp_getapplock below provides an exclusive
+            // per-semaphore serialisation point. SERIALIZABLE + range locks on an empty table
+            // causes deadlocks: two concurrent transactions take key-range locks on the empty
+            // SemaphoreName range, then deadlock when both try to INSERT.
+            await using var transaction = connection.BeginTransaction(System.Data.IsolationLevel.ReadCommitted);
+
+            try
+            {
+                // Acquire an exclusive application lock for this semaphore name, scoped to the
+                // transaction lifetime. sp_getapplock serialises all concurrent callers without
+                // requiring any existing rows (unlike UPDLOCK/HOLDLOCK on an empty range).
+                // Return values: 0 = granted, 1 = granted after waiting; < 0 = error/timeout.
+                const string appLockSql = @"
+                    DECLARE @result INT;
+                    EXEC @result = sp_getapplock
+                        @Resource    = @SemaphoreName,
+                        @LockMode    = 'Exclusive',
+                        @LockOwner   = 'Transaction',
+                        @LockTimeout = @TimeoutMs;
+                    IF @result < 0
+                        THROW 50001, 'sp_getapplock failed to acquire exclusive lock', 1;";
+
+                await using (var lockCommand = new SqlCommand(appLockSql, connection, transaction))
+                {
+                    lockCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    lockCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    lockCommand.Parameters.AddWithValue("@TimeoutMs", options.CommandTimeoutSeconds * 1000);
+                    await lockCommand.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                // Clean up expired holders
+                string cleanupSql = $@"
+                    DELETE FROM [{options.SchemaName}].[{options.TableName}]
+                    WHERE SemaphoreName = @SemaphoreName AND LastHeartbeat < @ExpiryTime";
+
+                await using (var cleanupCommand = new SqlCommand(cleanupSql, connection, transaction))
+                {
+                    cleanupCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    cleanupCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    cleanupCommand.Parameters.AddWithValue("@ExpiryTime", expiryTime);
+                    await cleanupCommand.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                // Check if holder already exists (renewal case)
+                string checkExistingSql = $@"
+                    SELECT COUNT(1) FROM [{options.SchemaName}].[{options.TableName}]
+                    WHERE SemaphoreName = @SemaphoreName AND HolderId = @HolderId";
+
+                await using (var checkCommand = new SqlCommand(checkExistingSql, connection, transaction))
+                {
+                    checkCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    checkCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    checkCommand.Parameters.AddWithValue("@HolderId", holderId);
+
+                    int existingCount = Convert.ToInt32(await checkCommand.ExecuteScalarAsync(cancellationToken));
+                    if (existingCount > 0)
+                    {
+                        string renewSql = $@"
+                            UPDATE [{options.SchemaName}].[{options.TableName}]
+                            SET LastHeartbeat = @Now, Metadata = @Metadata
+                            WHERE SemaphoreName = @SemaphoreName AND HolderId = @HolderId";
+
+                        await using var renewCommand = new SqlCommand(renewSql, connection, transaction);
+                        renewCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                        renewCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                        renewCommand.Parameters.AddWithValue("@HolderId", holderId);
+                        renewCommand.Parameters.AddWithValue("@Now", now);
+                        renewCommand.Parameters.AddWithValue("@Metadata", metadataJson);
+                        await renewCommand.ExecuteNonQueryAsync(cancellationToken);
+
+                        await transaction.CommitAsync(cancellationToken);
+                        logger.LogInformation("Renewed slot for holder {HolderId} in semaphore {SemaphoreName}",
+                            holderId, semaphoreName);
+                        return true;
+                    }
+                }
+
+                // Count current holders (app lock guarantees no concurrent mutations)
+                string countSql = $@"
+                    SELECT COUNT(1) FROM [{options.SchemaName}].[{options.TableName}]
+                    WHERE SemaphoreName = @SemaphoreName";
+
+                int currentCount;
+                await using (var countCommand = new SqlCommand(countSql, connection, transaction))
+                {
+                    countCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    countCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    currentCount = Convert.ToInt32(await countCommand.ExecuteScalarAsync(cancellationToken));
+                }
+
+                if (currentCount >= maxCount)
+                {
+                    await transaction.RollbackAsync(cancellationToken);
+                    logger.LogDebug("Failed to acquire slot for holder {HolderId} in semaphore {SemaphoreName} - full ({CurrentCount}/{MaxCount})",
+                        holderId, semaphoreName, currentCount, maxCount);
+                    return false;
+                }
+
+                // Insert new holder
+                string insertSql = $@"
+                    INSERT INTO [{options.SchemaName}].[{options.TableName}]
+                    (SemaphoreName, HolderId, AcquiredAt, LastHeartbeat, Metadata)
+                    VALUES (@SemaphoreName, @HolderId, @Now, @Now, @Metadata)";
+
+                await using (var insertCommand = new SqlCommand(insertSql, connection, transaction))
+                {
+                    insertCommand.CommandTimeout = options.CommandTimeoutSeconds;
+                    insertCommand.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+                    insertCommand.Parameters.AddWithValue("@HolderId", holderId);
+                    insertCommand.Parameters.AddWithValue("@Now", now);
+                    insertCommand.Parameters.AddWithValue("@Metadata", metadataJson);
+                    await insertCommand.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                await transaction.CommitAsync(cancellationToken);
+                logger.LogInformation("Acquired slot for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+                return true;
+            }
+            catch
+            {
+                try { await transaction.RollbackAsync(CancellationToken.None); } catch { /* already rolled back */ }
+                throw;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to acquire semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new SqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            string sql = $@"
+                DELETE FROM [{options.SchemaName}].[{options.TableName}]
+                WHERE SemaphoreName = @SemaphoreName AND HolderId = @HolderId";
+
+            await using var command = new SqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+            command.Parameters.AddWithValue("@HolderId", holderId);
+
+            int rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
+
+            logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}. Rows affected: {RowsAffected}",
+                holderId, semaphoreName, rowsAffected);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to release semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateHeartbeatAsync(
+        string semaphoreName,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMetadata(metadata);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new SqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            string metadataJson = JsonSerializer.Serialize(metadata);
+
+            string sql = $@"
+                UPDATE [{options.SchemaName}].[{options.TableName}]
+                SET LastHeartbeat = @Now, Metadata = @Metadata
+                WHERE SemaphoreName = @SemaphoreName AND HolderId = @HolderId";
+
+            await using var command = new SqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+            command.Parameters.AddWithValue("@HolderId", holderId);
+            command.Parameters.AddWithValue("@Now", now);
+            command.Parameters.AddWithValue("@Metadata", metadataJson);
+
+            int rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
+            return rowsAffected > 0;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to update heartbeat", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetCurrentCountAsync(
+        string semaphoreName,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new SqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            DateTimeOffset expiryTime = DateTimeOffset.UtcNow.Subtract(slotTimeout);
+
+            string sql = $@"
+                SELECT COUNT(1) FROM [{options.SchemaName}].[{options.TableName}]
+                WHERE SemaphoreName = @SemaphoreName AND LastHeartbeat >= @ExpiryTime";
+
+            await using var command = new SqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+            command.Parameters.AddWithValue("@ExpiryTime", expiryTime);
+
+            return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting current count for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get current count", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SemaphoreHolder>> GetHoldersAsync(
+        string semaphoreName,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new SqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            string sql = $@"
+                SELECT HolderId, AcquiredAt, LastHeartbeat, Metadata
+                FROM [{options.SchemaName}].[{options.TableName}]
+                WHERE SemaphoreName = @SemaphoreName
+                ORDER BY AcquiredAt";
+
+            await using var command = new SqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+
+            var holders = new List<SemaphoreHolder>();
+            await using SqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                string holderId = reader.GetString(reader.GetOrdinal("HolderId"));
+                DateTimeOffset acquiredAt = reader.GetDateTimeOffset(reader.GetOrdinal("AcquiredAt"));
+                DateTimeOffset lastHeartbeat = reader.GetDateTimeOffset(reader.GetOrdinal("LastHeartbeat"));
+                string metadataJson = reader.GetString(reader.GetOrdinal("Metadata"));
+
+                Dictionary<string, string> metadata = string.IsNullOrEmpty(metadataJson)
+                    ? new Dictionary<string, string>()
+                    : JsonSerializer.Deserialize<Dictionary<string, string>>(metadataJson) ?? new Dictionary<string, string>();
+
+                holders.Add(new SemaphoreHolder(holderId, acquiredAt, lastHeartbeat, metadata));
+            }
+
+            return holders;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get holders", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsHoldingAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = new SqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            string sql = $@"
+                SELECT COUNT(1) FROM [{options.SchemaName}].[{options.TableName}]
+                WHERE SemaphoreName = @SemaphoreName AND HolderId = @HolderId";
+
+            await using var command = new SqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+            command.Parameters.AddWithValue("@SemaphoreName", semaphoreName);
+            command.Parameters.AddWithValue("@HolderId", holderId);
+
+            return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error checking if holder {HolderId} is holding semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to check holding status", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
+    {
+        if (isDisposed)
+            return false;
+
+        try
+        {
+            await using var connection = new SqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = new SqlCommand("SELECT 1", connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+
+            await command.ExecuteScalarAsync(cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Health check failed for SQL Server semaphore provider");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (isDisposed) return;
+        isDisposed = true;
+        initializationLock.Dispose();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (isDisposed)
+            throw new ObjectDisposedException(nameof(SqlServerSemaphoreProvider));
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (isInitialized)
+            return;
+
+        await initializationLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (isInitialized)
+                return;
+
+            if (options.AutoCreateTable)
+                await CreateTableIfNotExistsAsync(cancellationToken);
+
+            isInitialized = true;
+        }
+        finally
+        {
+            initializationLock.Release();
+        }
+    }
+
+    private async Task CreateTableIfNotExistsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = new SqlConnection(options.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            // Use separate idempotent statements so a partial failure (e.g., table created but
+            // index not yet) is recovered on the next initialisation without skipping the index.
+            string tableName = options.TableName;
+            string pkName = $"PK_{(tableName.Length > 125 ? tableName[..125] : tableName)}";
+            string ixName = $"IX_{(tableName.Length > 97 ? tableName[..97] : tableName)}_SemaphoreName_LastHeartbeat";
+
+            string sql = $@"
+                IF OBJECT_ID(N'[{options.SchemaName}].[{tableName}]', N'U') IS NULL
+                BEGIN
+                    CREATE TABLE [{options.SchemaName}].[{tableName}] (
+                        SemaphoreName NVARCHAR(255) NOT NULL,
+                        HolderId NVARCHAR(255) NOT NULL,
+                        AcquiredAt DATETIMEOFFSET NOT NULL,
+                        LastHeartbeat DATETIMEOFFSET NOT NULL,
+                        Metadata NVARCHAR(MAX) NULL,
+                        CONSTRAINT {pkName} PRIMARY KEY (SemaphoreName, HolderId)
+                    );
+                END
+
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.indexes
+                    WHERE name = N'{ixName}'
+                      AND object_id = OBJECT_ID(N'[{options.SchemaName}].[{tableName}]')
+                )
+                BEGIN
+                    CREATE INDEX {ixName}
+                        ON [{options.SchemaName}].[{tableName}] (SemaphoreName, LastHeartbeat);
+                END";
+
+            await using var command = new SqlCommand(sql, connection);
+            command.CommandTimeout = options.CommandTimeoutSeconds;
+
+            await command.ExecuteNonQueryAsync(cancellationToken);
+
+            logger.LogInformation("Semaphore holders table [{Schema}].[{Table}] created or verified",
+                options.SchemaName, options.TableName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error creating semaphore holders table [{Schema}].[{Table}]",
+                options.SchemaName, options.TableName);
+            throw new SemaphoreProviderException("Failed to create semaphore holders table", ex);
+        }
+    }
+}

--- a/src/Providers/MultiLock.SqlServer/SqlServerSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.SqlServer/SqlServerSemaphoreProvider.cs
@@ -183,6 +183,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
                 throw;
             }
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
@@ -220,6 +224,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
 
             logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}. Rows affected: {RowsAffected}",
                 holderId, semaphoreName, rowsAffected);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -265,6 +273,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
             int rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
             return rowsAffected > 0;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
@@ -301,6 +313,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
             command.Parameters.AddWithValue("@ExpiryTime", expiryTime);
 
             return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -352,6 +368,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
 
             return holders;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
@@ -385,6 +405,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
             command.Parameters.AddWithValue("@HolderId", holderId);
 
             return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Providers/MultiLock.SqlServer/SqlServerServiceCollectionExtensions.cs
+++ b/src/Providers/MultiLock.SqlServer/SqlServerServiceCollectionExtensions.cs
@@ -3,10 +3,11 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MultiLock.SqlServer;
 
 /// <summary>
-/// Extension methods for configuring SQL Server leader election services.
+/// Extension methods for configuring SQL Server leader election and semaphore services.
 /// </summary>
 public static class SqlServerServiceCollectionExtensions
 {
+    // Leader Election Methods
     /// <summary>
     /// Adds SQL Server leader election services to the dependency injection container.
     /// </summary>
@@ -20,7 +21,7 @@ public static class SqlServerServiceCollectionExtensions
         Action<LeaderElectionOptions>? configureLeaderElectionOptions = null)
     {
         services.Configure(configureOptions);
-        
+
         if (configureLeaderElectionOptions != null)
         {
             services.Configure(configureLeaderElectionOptions);
@@ -44,5 +45,44 @@ public static class SqlServerServiceCollectionExtensions
         return services.AddSqlServerLeaderElection(
             options => options.ConnectionString = connectionString,
             configureLeaderElectionOptions);
+    }
+
+    // Semaphore Methods
+
+    /// <summary>
+    /// Adds SQL Server semaphore services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the SQL Server options.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddSqlServerSemaphore(
+        this IServiceCollection services,
+        Action<SqlServerSemaphoreOptions> configureOptions,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        services.Configure(configureOptions);
+
+        if (configureSemaphoreOptions != null)
+            services.Configure(configureSemaphoreOptions);
+
+        return services.AddSemaphore<SqlServerSemaphoreProvider>();
+    }
+
+    /// <summary>
+    /// Adds SQL Server semaphore services to the dependency injection container with connection string.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The SQL Server connection string.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddSqlServerSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddSqlServerSemaphore(
+            options => options.ConnectionString = connectionString,
+            configureSemaphoreOptions);
     }
 }

--- a/src/Providers/MultiLock.ZooKeeper/MultiLock.ZooKeeper.csproj
+++ b/src/Providers/MultiLock.ZooKeeper/MultiLock.ZooKeeper.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <PackageId>MultiLock.ZooKeeper</PackageId>
-    <Description>Apache ZooKeeper provider for MultiLock - Leader Election framework for distributed systems. This package includes the core MultiLock framework.</Description>
-    <PackageTags>leader-election;distributed-systems;high-availability;failover;zookeeper;apache;coordination</PackageTags>
+    <Description>Apache ZooKeeper provider for MultiLock - Leader Election and Distributed Semaphores framework for distributed systems. This package includes the core MultiLock framework.</Description>
+    <PackageTags>leader-election;distributed-systems;high-availability;failover;semaphore;rate-limiting;zookeeper;apache;coordination</PackageTags>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Providers/MultiLock.ZooKeeper/MultiLock.ZooKeeper.csproj
+++ b/src/Providers/MultiLock.ZooKeeper/MultiLock.ZooKeeper.csproj
@@ -14,6 +14,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="MultiLock.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
     <ProjectReference Include="..\..\MultiLock\MultiLock.csproj">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
       <IncludeAssets>MultiLock.dll</IncludeAssets>

--- a/src/Providers/MultiLock.ZooKeeper/ZooKeeperLeaderElectionOptions.cs
+++ b/src/Providers/MultiLock.ZooKeeper/ZooKeeperLeaderElectionOptions.cs
@@ -70,12 +70,12 @@ public sealed class ZooKeeperLeaderElectionOptions
 
         if (SessionTimeout <= TimeSpan.Zero || SessionTimeout > TimeSpan.FromMinutes(60))
         {
-            throw new ArgumentException("Session timeout must be between 0 and 60 minutes.", nameof(SessionTimeout));
+            throw new ArgumentException("Session timeout must be greater than 0 and at most 60 minutes.", nameof(SessionTimeout));
         }
 
         if (ConnectionTimeout <= TimeSpan.Zero || ConnectionTimeout > TimeSpan.FromMinutes(10))
         {
-            throw new ArgumentException("Connection timeout must be between 0 and 10 minutes.", nameof(ConnectionTimeout));
+            throw new ArgumentException("Connection timeout must be greater than 0 and at most 10 minutes.", nameof(ConnectionTimeout));
         }
 
         if (MaxRetries < 0 || MaxRetries > 10)

--- a/src/Providers/MultiLock.ZooKeeper/ZooKeeperLeaderElectionProvider.cs
+++ b/src/Providers/MultiLock.ZooKeeper/ZooKeeperLeaderElectionProvider.cs
@@ -534,7 +534,9 @@ public sealed class ZooKeeperLeaderElectionProvider : Watcher, ILeaderElectionPr
 
             try
             {
-                await connectionCompletionSource.Task.ConfigureAwait(false);
+                // WaitAsync links the TaskCompletionSource to the timeout/caller token so that
+                // cancellation actually propagates; awaiting the Task directly never cancels.
+                await connectionCompletionSource.Task.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (timeoutCts.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {

--- a/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreOptions.cs
+++ b/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreOptions.cs
@@ -1,0 +1,60 @@
+﻿namespace MultiLock.ZooKeeper;
+
+/// <summary>
+/// Configuration options for the ZooKeeper semaphore provider.
+/// </summary>
+public sealed class ZooKeeperSemaphoreOptions
+{
+    /// <summary>
+    /// Gets or sets the ZooKeeper connection string.
+    /// Default is "localhost:2181".
+    /// </summary>
+    public string ConnectionString { get; set; } = "localhost:2181";
+
+    /// <summary>
+    /// Gets or sets the root path for semaphore nodes in ZooKeeper.
+    /// Default is "/semaphores".
+    /// </summary>
+    public string RootPath { get; set; } = "/semaphores";
+
+    /// <summary>
+    /// Gets or sets the session timeout for ZooKeeper connections.
+    /// Default is 30 seconds.
+    /// </summary>
+    public TimeSpan SessionTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets the connection timeout for ZooKeeper connections.
+    /// Default is 10 seconds.
+    /// </summary>
+    public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically create the root path if it doesn't exist.
+    /// Default is true.
+    /// </summary>
+    public bool AutoCreateRootPath { get; set; } = true;
+
+    /// <summary>
+    /// Validates the configuration options.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when configuration is invalid.</exception>
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(ConnectionString))
+            throw new ArgumentException("Connection string cannot be null or empty.", nameof(ConnectionString));
+
+        if (string.IsNullOrWhiteSpace(RootPath))
+            throw new ArgumentException("Root path cannot be null or empty.", nameof(RootPath));
+
+        if (!RootPath.StartsWith('/'))
+            throw new ArgumentException("Root path must start with '/'.", nameof(RootPath));
+
+        if (SessionTimeout <= TimeSpan.Zero || SessionTimeout > TimeSpan.FromMinutes(60))
+            throw new ArgumentException("Session timeout must be greater than 0 and at most 60 minutes.", nameof(SessionTimeout));
+
+        if (ConnectionTimeout <= TimeSpan.Zero || ConnectionTimeout > TimeSpan.FromMinutes(10))
+            throw new ArgumentException("Connection timeout must be greater than 0 and at most 10 minutes.", nameof(ConnectionTimeout));
+    }
+}
+

--- a/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
@@ -1,0 +1,644 @@
+﻿using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.Exceptions;
+using org.apache.zookeeper;
+using org.apache.zookeeper.data;
+
+namespace MultiLock.ZooKeeper;
+
+/// <summary>
+/// ZooKeeper implementation of the semaphore provider.
+/// Uses ZooKeeper ephemeral sequential nodes for distributed counting semaphore.
+/// </summary>
+public sealed class ZooKeeperSemaphoreProvider : Watcher, ISemaphoreProvider, IAsyncDisposable
+{
+    private readonly ZooKeeperSemaphoreOptions options;
+    private readonly ILogger<ZooKeeperSemaphoreProvider> logger;
+    private readonly SemaphoreSlim initializationLock = new(1, 1);
+    private readonly Dictionary<string, Dictionary<string, string>> activeNodes = new();
+    private readonly object nodeLock = new();
+    private volatile bool isInitialized;
+    private volatile bool isDisposed;
+    private volatile bool sessionExpired;
+    private org.apache.zookeeper.ZooKeeper? zooKeeper;
+    private TaskCompletionSource? connectionCompletionSource;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ZooKeeperSemaphoreProvider"/> class.
+    /// </summary>
+    /// <param name="options">The ZooKeeper options.</param>
+    /// <param name="logger">The logger.</param>
+    public ZooKeeperSemaphoreProvider(
+        IOptions<ZooKeeperSemaphoreOptions> options,
+        ILogger<ZooKeeperSemaphoreProvider> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+
+        this.options.Validate();
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAcquireAsync(
+        string semaphoreName,
+        string holderId,
+        int maxCount,
+        IReadOnlyDictionary<string, string> metadata,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMaxCount(maxCount);
+        ParameterValidation.ValidateMetadata(metadata);
+        ParameterValidation.ValidateSlotTimeout(slotTimeout);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            string semaphorePath = GetSemaphorePath(semaphoreName);
+            await EnsurePathExistsAsync(semaphorePath);
+
+            // Check if we already have a node for this semaphore/holder
+            string? existingPath = GetExistingNode(semaphoreName, holderId);
+
+            if (existingPath != null)
+            {
+                Stat? stat = await zooKeeper!.existsAsync(existingPath);
+                if (stat != null)
+                {
+                    // Already holding a slot
+                    logger.LogDebug("Holder {HolderId} already has a slot in semaphore {SemaphoreName}",
+                        holderId, semaphoreName);
+                    return true;
+                }
+                // Node doesn't exist anymore, remove from tracking
+                RemoveNode(semaphoreName, holderId);
+            }
+
+            // Get current count
+            ChildrenResult? children = await zooKeeper!.getChildrenAsync(semaphorePath);
+            if (children.Children.Count >= maxCount)
+            {
+                logger.LogDebug("Semaphore {SemaphoreName} is full ({Count}/{MaxCount})",
+                    semaphoreName, children.Children.Count, maxCount);
+                return false;
+            }
+
+            // Create ephemeral sequential node
+            string createdPath = await CreateHolderNodeAsync(semaphorePath, holderId, metadata);
+            AddNode(semaphoreName, holderId, createdPath);
+
+            // Verify we're within the limit (race condition check)
+            children = await zooKeeper.getChildrenAsync(semaphorePath);
+            var sortedChildren = children.Children.OrderBy(c => c).ToList();
+            string createdNodeName = createdPath[(createdPath.LastIndexOf('/') + 1)..];
+            int position = sortedChildren.IndexOf(createdNodeName);
+
+            // position == -1 means the node was already deleted (e.g., session expired between
+            // create and the children refresh); treat it the same as being over the limit.
+            if (position < 0 || position >= maxCount)
+            {
+                // We're over the limit or the node disappeared - release our slot
+                RemoveNode(semaphoreName, holderId);
+                try
+                {
+                    await zooKeeper.deleteAsync(createdPath);
+                }
+                catch (KeeperException.NoNodeException)
+                {
+                    // Already gone, nothing to do
+                }
+                logger.LogDebug("Semaphore {SemaphoreName} became full during acquisition (position={Position}), releasing slot",
+                    semaphoreName, position);
+                return false;
+            }
+
+            logger.LogInformation("Holder {HolderId} acquired slot in semaphore {SemaphoreName} (position {Position}/{MaxCount})",
+                holderId, semaphoreName, position + 1, maxCount);
+            return true;
+        }
+        catch (KeeperException.SessionExpiredException ex)
+        {
+            HandleSessionExpired(ex, "acquiring slot", holderId, semaphoreName);
+            throw new SemaphoreProviderException("ZooKeeper session expired", ex);
+        }
+        catch (Exception ex) when (ex is not SemaphoreException)
+        {
+            logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to acquire semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            string? nodePath = RemoveNode(semaphoreName, holderId);
+            if (nodePath == null)
+            {
+                logger.LogWarning("No active node found for holder {HolderId} in semaphore {SemaphoreName}",
+                    holderId, semaphoreName);
+                return;
+            }
+
+            await zooKeeper!.deleteAsync(nodePath);
+            logger.LogInformation("Holder {HolderId} released slot in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+        }
+        catch (KeeperException.NoNodeException)
+        {
+            // Node already deleted, ignore
+            logger.LogDebug("Node already deleted for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+        }
+        catch (KeeperException.SessionExpiredException ex)
+        {
+            HandleSessionExpired(ex, "releasing slot", holderId, semaphoreName);
+            throw new SemaphoreProviderException("ZooKeeper session expired", ex);
+        }
+        catch (Exception ex) when (ex is not SemaphoreException)
+        {
+            logger.LogError(ex, "Error releasing slot for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to release semaphore slot", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateHeartbeatAsync(
+        string semaphoreName,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        ParameterValidation.ValidateMetadata(metadata);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            string? nodePath = GetExistingNode(semaphoreName, holderId);
+            if (nodePath == null)
+                return false;
+
+            DataResult? result = await zooKeeper!.getDataAsync(nodePath);
+            if (result?.Data == null)
+                return false;
+
+            HolderData? existingData = JsonSerializer.Deserialize<HolderData>(Encoding.UTF8.GetString(result.Data));
+            if (existingData?.HolderId != holderId)
+                return false;
+
+            existingData.LastHeartbeat = DateTimeOffset.UtcNow;
+            existingData.Metadata = new Dictionary<string, string>(metadata);
+
+            string json = JsonSerializer.Serialize(existingData);
+            byte[] data = Encoding.UTF8.GetBytes(json);
+            await zooKeeper.setDataAsync(nodePath, data, result.Stat.getVersion());
+
+            logger.LogDebug("Updated heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            return true;
+        }
+        catch (KeeperException.SessionExpiredException ex)
+        {
+            HandleSessionExpired(ex, "updating heartbeat", holderId, semaphoreName);
+            return false;
+        }
+        catch (Exception ex) when (ex is not SemaphoreException)
+        {
+            logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to update heartbeat", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetCurrentCountAsync(
+        string semaphoreName,
+        TimeSpan slotTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            // ZooKeeper ephemeral nodes are automatically deleted when the session expires,
+            // so counting children gives the live holder count without additional filtering.
+            string semaphorePath = GetSemaphorePath(semaphoreName);
+            Stat? pathStat = await zooKeeper!.existsAsync(semaphorePath);
+            if (pathStat == null)
+                return 0;
+
+            ChildrenResult? children = await zooKeeper.getChildrenAsync(semaphorePath);
+            return children.Children.Count;
+        }
+        catch (KeeperException.SessionExpiredException ex)
+        {
+            logger.LogWarning(ex, "ZooKeeper session expired while getting count for semaphore {SemaphoreName}",
+                semaphoreName);
+            sessionExpired = true;
+            isInitialized = false;
+            throw new SemaphoreProviderException("ZooKeeper session expired", ex);
+        }
+        catch (Exception ex) when (ex is not SemaphoreException)
+        {
+            logger.LogError(ex, "Error getting count for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get semaphore count", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SemaphoreHolder>> GetHoldersAsync(
+        string semaphoreName,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            string semaphorePath = GetSemaphorePath(semaphoreName);
+            Stat? pathStat = await zooKeeper!.existsAsync(semaphorePath);
+            if (pathStat == null)
+                return [];
+
+            ChildrenResult? children = await zooKeeper.getChildrenAsync(semaphorePath);
+            var holders = new List<SemaphoreHolder>();
+
+            foreach (string child in children.Children)
+            {
+                string childPath = $"{semaphorePath}/{child}";
+                try
+                {
+                    DataResult? result = await zooKeeper.getDataAsync(childPath);
+                    HolderData? holderData = JsonSerializer.Deserialize<HolderData>(Encoding.UTF8.GetString(result.Data));
+                    if (holderData != null)
+                    {
+                        holders.Add(new SemaphoreHolder(
+                            holderData.HolderId,
+                            holderData.AcquiredAt,
+                            holderData.LastHeartbeat,
+                            holderData.Metadata));
+                    }
+                }
+                catch (KeeperException.NoNodeException)
+                {
+                    // Node was deleted between listing and reading, skip
+                }
+            }
+
+            return holders;
+        }
+        catch (KeeperException.SessionExpiredException ex)
+        {
+            logger.LogWarning(ex, "ZooKeeper session expired while getting holders for semaphore {SemaphoreName}",
+                semaphoreName);
+            sessionExpired = true;
+            isInitialized = false;
+            throw new SemaphoreProviderException("ZooKeeper session expired", ex);
+        }
+        catch (Exception ex) when (ex is not SemaphoreException)
+        {
+            logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
+            throw new SemaphoreProviderException("Failed to get semaphore holders", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsHoldingAsync(
+        string semaphoreName,
+        string holderId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ParameterValidation.ValidateSemaphoreName(semaphoreName);
+        ParameterValidation.ValidateHolderId(holderId);
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            string? nodePath = GetExistingNode(semaphoreName, holderId);
+            if (nodePath == null)
+                return false;
+
+            Stat? stat = await zooKeeper!.existsAsync(nodePath);
+            return stat != null;
+        }
+        catch (KeeperException.SessionExpiredException ex)
+        {
+            HandleSessionExpired(ex, "checking holding status", holderId, semaphoreName);
+            return false;
+        }
+        catch (Exception ex) when (ex is not SemaphoreException)
+        {
+            logger.LogError(ex, "Error checking if holder {HolderId} is holding semaphore {SemaphoreName}",
+                holderId, semaphoreName);
+            throw new SemaphoreProviderException("Failed to check holding status", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
+    {
+        if (isDisposed)
+            return false;
+
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken);
+            org.apache.zookeeper.ZooKeeper.States? state = zooKeeper?.getState();
+            return state == org.apache.zookeeper.ZooKeeper.States.CONNECTED;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Health check failed for ZooKeeper semaphore provider");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the ZooKeeper semaphore provider and releases all resources.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (isDisposed)
+            return;
+
+        isDisposed = true;
+
+        if (zooKeeper != null)
+        {
+            try
+            {
+                await zooKeeper.closeAsync();
+            }
+            catch (Exception ex) when (ex is not SystemException)
+            {
+                logger.LogWarning(ex, "Error closing ZooKeeper connection during disposal");
+            }
+        }
+
+        initializationLock.Dispose();
+    }
+
+    /// <summary>
+    /// Synchronously disposes the ZooKeeper semaphore provider.
+    /// <remarks>
+    /// Prefer <see cref="DisposeAsync"/> in async contexts. This synchronous path blocks the
+    /// calling thread and should not be used when a synchronization context is active.
+    /// </remarks>
+    public void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc />
+    public override Task process(WatchedEvent @event)
+    {
+        logger.LogDebug("ZooKeeper event received: {EventType} for path {Path}", @event.get_Type(), @event.getPath());
+
+        if (@event.get_Type() != Event.EventType.None)
+            return Task.CompletedTask;
+
+        Event.KeeperState state = @event.getState();
+        switch (state)
+        {
+            case Event.KeeperState.Expired:
+                logger.LogWarning("ZooKeeper session expired, marking for reconnection");
+                sessionExpired = true;
+                isInitialized = false;
+                lock (nodeLock)
+                {
+                    activeNodes.Clear();
+                }
+                break;
+            case Event.KeeperState.Disconnected:
+                logger.LogWarning("ZooKeeper connection lost");
+                break;
+            case Event.KeeperState.SyncConnected:
+                logger.LogInformation("ZooKeeper connection established/restored");
+                connectionCompletionSource?.TrySetResult();
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (!isDisposed) return;
+        throw new ObjectDisposedException(nameof(ZooKeeperSemaphoreProvider));
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (isInitialized && !sessionExpired)
+            return;
+
+        await initializationLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (isInitialized && !sessionExpired)
+                return;
+
+            if (sessionExpired && zooKeeper != null)
+            {
+                try
+                {
+                    await zooKeeper.closeAsync();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Error closing expired ZooKeeper session");
+                }
+                zooKeeper = null;
+                sessionExpired = false;
+            }
+
+            string connectionString = options.ConnectionString;
+            int sessionTimeout = (int)options.SessionTimeout.TotalMilliseconds;
+
+            connectionCompletionSource = new TaskCompletionSource();
+            zooKeeper = new org.apache.zookeeper.ZooKeeper(connectionString, sessionTimeout, this);
+
+            if (zooKeeper.getState() == org.apache.zookeeper.ZooKeeper.States.CONNECTED)
+                connectionCompletionSource.TrySetResult();
+
+            TimeSpan connectionTimeout = options.ConnectionTimeout;
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(connectionTimeout);
+
+            try
+            {
+                // WaitAsync links the TaskCompletionSource to the timeout/caller token so that
+                // cancellation actually propagates; awaiting the Task directly never cancels.
+                await connectionCompletionSource.Task.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                // Close the ZooKeeper instance that was created but never connected, so that
+                // its background socket/watcher threads are not leaked.
+                var leakedZk = zooKeeper;
+                zooKeeper = null;
+                if (leakedZk != null)
+                {
+                    try
+                    {
+                        await leakedZk.closeAsync();
+                    }
+                    catch (Exception closeEx)
+                    {
+                        logger.LogWarning(closeEx, "Error closing ZooKeeper instance after connection timeout");
+                    }
+                }
+                throw new SemaphoreProviderException("Failed to connect to ZooKeeper within timeout");
+            }
+            finally
+            {
+                connectionCompletionSource = null;
+            }
+
+            if (options.AutoCreateRootPath)
+                await EnsurePathExistsAsync(options.RootPath);
+
+            isInitialized = true;
+            logger.LogInformation("ZooKeeper connection established to {ConnectionString}", options.ConnectionString);
+        }
+        finally
+        {
+            initializationLock.Release();
+        }
+    }
+
+    private async Task EnsurePathExistsAsync(string path)
+    {
+        if (string.IsNullOrEmpty(path) || path == "/")
+            return;
+
+        Stat? stat = await zooKeeper!.existsAsync(path);
+        if (stat != null)
+            return;
+
+        string parentPath = path[..path.LastIndexOf('/')];
+        if (!string.IsNullOrEmpty(parentPath) && parentPath != "/")
+            await EnsurePathExistsAsync(parentPath);
+
+        try
+        {
+            await zooKeeper.createAsync(path, [], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            logger.LogDebug("Created ZooKeeper path: {Path}", path);
+        }
+        catch (KeeperException.NodeExistsException)
+        {
+            // Path was created by another process, ignore
+        }
+    }
+
+    private async Task<string> CreateHolderNodeAsync(
+        string semaphorePath,
+        string holderId,
+        IReadOnlyDictionary<string, string> metadata)
+    {
+        var holderData = new HolderData
+        {
+            HolderId = holderId,
+            AcquiredAt = DateTimeOffset.UtcNow,
+            LastHeartbeat = DateTimeOffset.UtcNow,
+            Metadata = new Dictionary<string, string>(metadata)
+        };
+
+        string json = JsonSerializer.Serialize(holderData);
+        byte[] data = Encoding.UTF8.GetBytes(json);
+
+        string nodePath = $"{semaphorePath}/{holderId}-";
+        return await zooKeeper!.createAsync(nodePath, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+    }
+
+    private string GetSemaphorePath(string semaphoreName)
+    {
+        return $"{options.RootPath}/{semaphoreName}";
+    }
+
+    private string? GetExistingNode(string semaphoreName, string holderId)
+    {
+        lock (nodeLock)
+        {
+            if (activeNodes.TryGetValue(semaphoreName, out Dictionary<string, string>? holderNodes))
+                if (holderNodes.TryGetValue(holderId, out string? nodePath))
+                    return nodePath;
+            return null;
+        }
+    }
+
+    private void AddNode(string semaphoreName, string holderId, string nodePath)
+    {
+        lock (nodeLock)
+        {
+            if (!activeNodes.TryGetValue(semaphoreName, out Dictionary<string, string>? holderNodes))
+            {
+                holderNodes = new Dictionary<string, string>();
+                activeNodes[semaphoreName] = holderNodes;
+            }
+            holderNodes[holderId] = nodePath;
+        }
+    }
+
+    private string? RemoveNode(string semaphoreName, string holderId)
+    {
+        lock (nodeLock)
+        {
+            if (!activeNodes.TryGetValue(semaphoreName, out Dictionary<string, string>? holderNodes))
+                return null;
+            if (!holderNodes.Remove(holderId, out string? nodePath))
+                return null;
+            if (holderNodes.Count == 0)
+                activeNodes.Remove(semaphoreName);
+            return nodePath;
+        }
+    }
+
+    private void HandleSessionExpired(KeeperException.SessionExpiredException ex, string operation, string holderId, string semaphoreName)
+    {
+        logger.LogWarning(ex, "ZooKeeper session expired while {Operation} for holder {HolderId} in semaphore {SemaphoreName}",
+            operation, holderId, semaphoreName);
+        sessionExpired = true;
+        isInitialized = false;
+        lock (nodeLock)
+        {
+            // Session expiry invalidates ALL ephemeral nodes, not just those for the given semaphore.
+            activeNodes.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Internal class to represent holder data stored in ZooKeeper.
+    /// </summary>
+    private sealed class HolderData
+    {
+        public string HolderId { get; init; } = string.Empty;
+        public DateTimeOffset AcquiredAt { get; init; }
+        public DateTimeOffset LastHeartbeat { get; set; }
+        public Dictionary<string, string> Metadata { get; set; } = new();
+    }
+}
+

--- a/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
@@ -12,6 +12,18 @@ namespace MultiLock.ZooKeeper;
 /// ZooKeeper implementation of the semaphore provider.
 /// Uses ZooKeeper ephemeral sequential nodes for distributed counting semaphore.
 /// </summary>
+/// <remarks>
+/// Expiry semantics differ from the other providers. A slot is held by an <em>ephemeral</em> znode
+/// that lives as long as the holder's ZooKeeper session, so liveness is governed by the ZooKeeper
+/// session timeout rather than by the <c>slotTimeout</c> heartbeat window: the <c>slotTimeout</c>
+/// argument is not used to expire slots, and <see cref="GetCurrentCountAsync"/> counts live znodes
+/// regardless of last-heartbeat age. A holder that stops calling <see cref="UpdateHeartbeatAsync"/>
+/// but keeps its session alive therefore retains its slot until the session ends, at which point
+/// ZooKeeper removes the ephemeral node automatically and frees the slot. If the session expires,
+/// the slot is lost immediately; the next <see cref="UpdateHeartbeatAsync"/> call detects this
+/// (its node no longer exists) and reports the slot as lost so the service re-acquires.
+/// Tune the configured session timeout to match the desired failure-detection window.
+/// </remarks>
 public sealed class ZooKeeperSemaphoreProvider : Watcher, ISemaphoreProvider, IAsyncDisposable
 {
     private readonly ZooKeeperSemaphoreOptions options;
@@ -221,6 +233,16 @@ public sealed class ZooKeeperSemaphoreProvider : Watcher, ISemaphoreProvider, IA
             HandleSessionExpired(ex, "updating heartbeat", holderId, semaphoreName);
             return false;
         }
+        catch (Exception ex) when (ex is KeeperException.NoNodeException or KeeperException.BadVersionException)
+        {
+            // The node was removed (e.g. session lapsed and the ephemeral node was reaped, or it was
+            // deleted out of band) or updated concurrently: the slot is lost. Drop stale tracking and
+            // report the heartbeat as failed so the service re-acquires, per the provider contract.
+            RemoveNode(semaphoreName, holderId);
+            logger.LogWarning("Heartbeat for holder {HolderId} in semaphore {SemaphoreName} found no live node - slot lost",
+                holderId, semaphoreName);
+            return false;
+        }
         catch (Exception ex) when (ex is not SemaphoreException)
         {
             logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
@@ -403,6 +425,7 @@ public sealed class ZooKeeperSemaphoreProvider : Watcher, ISemaphoreProvider, IA
 
     /// <summary>
     /// Synchronously disposes the ZooKeeper semaphore provider.
+    /// </summary>
     /// <remarks>
     /// Prefer <see cref="DisposeAsync"/> in async contexts. This synchronous path blocks the
     /// calling thread and should not be used when a synchronization context is active.

--- a/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
@@ -106,7 +106,13 @@ public sealed class ZooKeeperSemaphoreProvider : Watcher, ISemaphoreProvider, IA
 
             // Verify we're within the limit (race condition check)
             children = await zooKeeper.getChildrenAsync(semaphorePath);
-            var sortedChildren = children.Children.OrderBy(c => c).ToList();
+            // Order by the ZooKeeper-assigned sequence suffix, NOT the full node name: names are
+            // "{holderId}-{seq}", so a lexicographic sort is dominated by the holder ID and does
+            // not reflect creation order. Sorting by name would let a later creator whose ID sorts
+            // before an established holder's rank itself within maxCount and be admitted, pushing
+            // the live holder count past the limit. Sequence order makes the position check match
+            // actual acquisition order so exactly the first maxCount creators keep their slots.
+            var sortedChildren = children.Children.OrderBy(GetSequenceNumber).ToList();
             string createdNodeName = createdPath[(createdPath.LastIndexOf('/') + 1)..];
             int position = sortedChildren.IndexOf(createdNodeName);
 
@@ -600,6 +606,28 @@ public sealed class ZooKeeperSemaphoreProvider : Watcher, ISemaphoreProvider, IA
     private string GetSemaphorePath(string semaphoreName)
     {
         return $"{options.RootPath}/{semaphoreName}";
+    }
+
+    // Extracts the ZooKeeper-assigned sequence number from a sequential node name of the form
+    // "{holderId}-{seq}". Holder IDs may themselves contain hyphens, so take the suffix after the
+    // LAST hyphen. NumberStyles.None restricts the suffix to plain ASCII digits (no sign or
+    // whitespace), matching ZooKeeper's zero-padded suffix format exactly. Nodes whose suffix does
+    // not parse under those rules (unexpected foreign nodes) sort last so they can never displace
+    // a validly created holder from its position.
+    internal static long GetSequenceNumber(string nodeName)
+    {
+        int separatorIndex = nodeName.LastIndexOf('-');
+        if (separatorIndex >= 0 && separatorIndex < nodeName.Length - 1
+            && long.TryParse(
+                nodeName.AsSpan(separatorIndex + 1),
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out long sequence))
+        {
+            return sequence;
+        }
+
+        return long.MaxValue;
     }
 
     private string? GetExistingNode(string semaphoreName, string holderId)

--- a/src/Providers/MultiLock.ZooKeeper/ZooKeeperServiceCollectionExtensions.cs
+++ b/src/Providers/MultiLock.ZooKeeper/ZooKeeperServiceCollectionExtensions.cs
@@ -3,10 +3,12 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MultiLock.ZooKeeper;
 
 /// <summary>
-/// Extension methods for configuring ZooKeeper leader election services.
+/// Extension methods for configuring ZooKeeper leader election and semaphore services.
 /// </summary>
 public static class ZooKeeperServiceCollectionExtensions
 {
+    // Leader Election Methods
+
     /// <summary>
     /// Adds ZooKeeper leader election services to the dependency injection container.
     /// </summary>
@@ -20,11 +22,9 @@ public static class ZooKeeperServiceCollectionExtensions
         Action<LeaderElectionOptions>? configureLeaderElectionOptions = null)
     {
         services.Configure(configureOptions);
-        
+
         if (configureLeaderElectionOptions != null)
-        {
             services.Configure(configureLeaderElectionOptions);
-        }
 
         return services.AddLeaderElection<ZooKeeperLeaderElectionProvider>();
     }
@@ -93,5 +93,93 @@ public static class ZooKeeperServiceCollectionExtensions
                 options.SessionTimeout = sessionTimeout;
             },
             configureLeaderElectionOptions);
+    }
+
+    // Semaphore Methods
+
+    /// <summary>
+    /// Adds ZooKeeper semaphore services to the dependency injection container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">An action to configure the ZooKeeper options.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddZooKeeperSemaphore(
+        this IServiceCollection services,
+        Action<ZooKeeperSemaphoreOptions> configureOptions,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        services.Configure(configureOptions);
+
+        if (configureSemaphoreOptions != null)
+            services.Configure(configureSemaphoreOptions);
+
+        return services.AddSemaphore<ZooKeeperSemaphoreProvider>();
+    }
+
+    /// <summary>
+    /// Adds ZooKeeper semaphore services to the dependency injection container with connection string.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The ZooKeeper connection string.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddZooKeeperSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddZooKeeperSemaphore(
+            options => options.ConnectionString = connectionString,
+            configureSemaphoreOptions);
+    }
+
+    /// <summary>
+    /// Adds ZooKeeper semaphore services to the dependency injection container with connection string and root path.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The ZooKeeper connection string.</param>
+    /// <param name="rootPath">The root path for semaphore nodes.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddZooKeeperSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        string rootPath,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddZooKeeperSemaphore(
+            options =>
+            {
+                options.ConnectionString = connectionString;
+                options.RootPath = rootPath;
+            },
+            configureSemaphoreOptions);
+    }
+
+    /// <summary>
+    /// Adds ZooKeeper semaphore services to the dependency injection container with full configuration.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The ZooKeeper connection string.</param>
+    /// <param name="rootPath">The root path for semaphore nodes.</param>
+    /// <param name="sessionTimeout">The session timeout for ZooKeeper connections.</param>
+    /// <param name="configureSemaphoreOptions">An action to configure the semaphore options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddZooKeeperSemaphore(
+        this IServiceCollection services,
+        string connectionString,
+        string rootPath,
+        TimeSpan sessionTimeout,
+        Action<SemaphoreOptions>? configureSemaphoreOptions = null)
+    {
+        return services.AddZooKeeperSemaphore(
+            options =>
+            {
+                options.ConnectionString = connectionString;
+                options.RootPath = rootPath;
+                options.SessionTimeout = sessionTimeout;
+            },
+            configureSemaphoreOptions);
     }
 }

--- a/tests/MultiLock.IntegrationTests/AzureBlobStorageSemaphoreIntegrationTests.cs
+++ b/tests/MultiLock.IntegrationTests/AzureBlobStorageSemaphoreIntegrationTests.cs
@@ -1,0 +1,180 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.AzureBlobStorage;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.IntegrationTests;
+
+[Collection("AzureBlobStorage")]
+public class AzureBlobStorageSemaphoreIntegrationTests : IAsyncLifetime
+{
+    private const string ConnectionString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
+    private readonly ILoggerFactory loggerFactory;
+    private readonly ILogger<AzureBlobStorageSemaphoreProvider> logger;
+    private readonly string containerName;
+
+    public AzureBlobStorageSemaphoreIntegrationTests()
+    {
+        loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        logger = loggerFactory.CreateLogger<AzureBlobStorageSemaphoreProvider>();
+        containerName = $"test-semaphore-{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        if (!await IsAzuriteAvailableAsync())
+            throw new InvalidOperationException("Azurite is not available. Make sure Azurite is running on localhost:10000");
+    }
+
+    public Task DisposeAsync()
+    {
+        loggerFactory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task HealthCheck_WithAzurite_ShouldReturnTrue()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new AzureBlobStorageSemaphoreProvider(Options.Create(options), logger);
+
+        // Act
+        bool isHealthy = await provider.HealthCheckAsync();
+
+        // Assert
+        isHealthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new AzureBlobStorageSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "test", "value" } };
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new AzureBlobStorageSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 2;
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire");
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-3", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderAlreadyHasSlot_ShouldRenew()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new AzureBlobStorageSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+        count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_ShouldAllowNewHolder()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new AzureBlobStorageSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 1;
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+
+        // Act
+        await provider.ReleaseAsync("test-semaphore", "holder-1");
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_ShouldReturnCorrectCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new AzureBlobStorageSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-2", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire");
+
+        // Act
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+
+        // Assert
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_ShouldReturnCorrectStatus()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new AzureBlobStorageSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool isHoldingBefore = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("should acquire");
+        bool isHoldingAfter = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+
+        // Assert
+        isHoldingBefore.ShouldBeFalse();
+        isHoldingAfter.ShouldBeTrue();
+    }
+
+    private AzureBlobStorageSemaphoreOptions CreateOptions() => new()
+    {
+        ConnectionString = ConnectionString,
+        ContainerName = containerName,
+        AutoCreateContainer = true,
+        MaxRetryAttempts = 5
+    };
+
+    private async Task<bool> IsAzuriteAvailableAsync()
+    {
+        try
+        {
+            var options = CreateOptions();
+            using var provider = new AzureBlobStorageSemaphoreProvider(Options.Create(options), logger);
+            return await provider.HealthCheckAsync();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+

--- a/tests/MultiLock.IntegrationTests/ConsulSemaphoreIntegrationTests.cs
+++ b/tests/MultiLock.IntegrationTests/ConsulSemaphoreIntegrationTests.cs
@@ -1,0 +1,180 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.Consul;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.IntegrationTests;
+
+[Collection("Consul")]
+public class ConsulSemaphoreIntegrationTests : IAsyncLifetime
+{
+    private const string Address = "http://localhost:8500";
+    private readonly ILoggerFactory loggerFactory;
+    private readonly ILogger<ConsulSemaphoreProvider> logger;
+    private readonly string keyPrefix;
+
+    public ConsulSemaphoreIntegrationTests()
+    {
+        loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        logger = loggerFactory.CreateLogger<ConsulSemaphoreProvider>();
+        keyPrefix = $"test-semaphore-{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        if (!await IsConsulAvailableAsync())
+            throw new InvalidOperationException("Consul is not available. Make sure Consul is running on localhost:8500");
+    }
+
+    public Task DisposeAsync()
+    {
+        loggerFactory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task HealthCheck_WithConsul_ShouldReturnTrue()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ConsulSemaphoreProvider(Options.Create(options), logger);
+
+        // Act
+        bool isHealthy = await provider.HealthCheckAsync();
+
+        // Assert
+        isHealthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ConsulSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "test", "value" } };
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ConsulSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 2;
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire a slot");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire a slot");
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-3", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderAlreadyHasSlot_ShouldRenew()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ConsulSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire the initial slot");
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+        count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_ShouldAllowNewHolder()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ConsulSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 1;
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire the initial slot");
+
+        // Act
+        await provider.ReleaseAsync("test-semaphore", "holder-1");
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_ShouldReturnCorrectCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ConsulSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire a slot");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-2", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire a slot");
+
+        // Act
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+
+        // Assert
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_ShouldReturnCorrectStatus()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ConsulSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool isHoldingBefore = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire a slot");
+        bool isHoldingAfter = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+
+        // Assert
+        isHoldingBefore.ShouldBeFalse();
+        isHoldingAfter.ShouldBeTrue();
+    }
+
+    private ConsulSemaphoreOptions CreateOptions() => new()
+    {
+        Address = Address,
+        KeyPrefix = keyPrefix,
+        SessionTtl = TimeSpan.FromSeconds(60),
+        SessionLockDelay = TimeSpan.FromSeconds(15)
+    };
+
+    private async Task<bool> IsConsulAvailableAsync()
+    {
+        try
+        {
+            var options = CreateOptions();
+            using var provider = new ConsulSemaphoreProvider(Options.Create(options), logger);
+            return await provider.HealthCheckAsync();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+

--- a/tests/MultiLock.IntegrationTests/ConsulSemaphoreIntegrationTests.cs
+++ b/tests/MultiLock.IntegrationTests/ConsulSemaphoreIntegrationTests.cs
@@ -155,6 +155,48 @@ public class ConsulSemaphoreIntegrationTests : IAsyncLifetime
         isHoldingAfter.ShouldBeTrue();
     }
 
+    [Fact]
+    public async Task TryAcquireAsync_ConcurrentAcquirers_NeverExceedsMaxCount()
+    {
+        // Arrange: many independent providers (simulating separate processes) race to acquire the
+        // same semaphore whose capacity is far smaller than the number of contenders. This exercises
+        // the optimistic pre-check / post-check rollback path that bounds the holder count.
+        const int maxCount = 3;
+        const int concurrency = 12;
+        const string semaphore = "concurrency-semaphore";
+        var metadata = new Dictionary<string, string>();
+        var options = CreateOptions();
+
+        var providers = Enumerable
+            .Range(0, concurrency)
+            .Select(_ => new ConsulSemaphoreProvider(Options.Create(options), logger))
+            .ToList();
+
+        try
+        {
+            // Act: fire all acquisitions concurrently.
+            bool[] results = await Task.WhenAll(
+                providers.Select((p, i) =>
+                    p.TryAcquireAsync(semaphore, $"holder-{i}", maxCount, metadata, TimeSpan.FromMinutes(5))));
+
+            int successes = results.Count(acquired => acquired);
+
+            // Assert: the safety invariant — no more than maxCount callers may hold a slot, and the
+            // authoritative live count must agree with the number of successful acquisitions (every
+            // rolled-back acquisition has already destroyed its session/key before returning).
+            successes.ShouldBeLessThanOrEqualTo(maxCount);
+
+            int count = await providers[0].GetCurrentCountAsync(semaphore, TimeSpan.FromMinutes(5));
+            count.ShouldBeLessThanOrEqualTo(maxCount);
+            count.ShouldBe(successes, "the live holder count should match the number of successful acquisitions");
+        }
+        finally
+        {
+            foreach (ConsulSemaphoreProvider provider in providers)
+                await provider.DisposeAsync();
+        }
+    }
+
     private ConsulSemaphoreOptions CreateOptions() => new()
     {
         Address = Address,

--- a/tests/MultiLock.IntegrationTests/FileSystemSemaphoreIntegrationTests.cs
+++ b/tests/MultiLock.IntegrationTests/FileSystemSemaphoreIntegrationTests.cs
@@ -1,0 +1,162 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.FileSystem;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.IntegrationTests;
+
+public class FileSystemSemaphoreIntegrationTests : IAsyncLifetime
+{
+    private readonly ILoggerFactory loggerFactory;
+    private readonly ILogger<FileSystemSemaphoreProvider> logger;
+    private readonly string directoryPath;
+
+    public FileSystemSemaphoreIntegrationTests()
+    {
+        loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        logger = loggerFactory.CreateLogger<FileSystemSemaphoreProvider>();
+        directoryPath = Path.Combine(Path.GetTempPath(), $"test-semaphore-{Guid.NewGuid():N}");
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync()
+    {
+        loggerFactory.Dispose();
+        // Clean up test directory
+        if (Directory.Exists(directoryPath))
+            Directory.Delete(directoryPath, true);
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task HealthCheck_WithFileSystem_ShouldReturnTrue()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new FileSystemSemaphoreProvider(Options.Create(options), logger);
+
+        // Act
+        bool isHealthy = await provider.HealthCheckAsync();
+
+        // Assert
+        isHealthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new FileSystemSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "test", "value" } };
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new FileSystemSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 2;
+
+        await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5));
+        await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-3", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderAlreadyHasSlot_ShouldRenew()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new FileSystemSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+        count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_ShouldAllowNewHolder()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new FileSystemSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 1;
+
+        await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Act
+        await provider.ReleaseAsync("test-semaphore", "holder-1");
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_ShouldReturnCorrectCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new FileSystemSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        await provider.TryAcquireAsync("test-semaphore", "holder-1", 5, metadata, TimeSpan.FromMinutes(5));
+        await provider.TryAcquireAsync("test-semaphore", "holder-2", 5, metadata, TimeSpan.FromMinutes(5));
+
+        // Act
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+
+        // Assert
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_ShouldReturnCorrectStatus()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new FileSystemSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool isHoldingBefore = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+        await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+        bool isHoldingAfter = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+
+        // Assert
+        isHoldingBefore.ShouldBeFalse();
+        isHoldingAfter.ShouldBeTrue();
+    }
+
+    private FileSystemSemaphoreOptions CreateOptions() => new()
+    {
+        DirectoryPath = directoryPath,
+        FileExtension = ".holder",
+        AutoCreateDirectory = true
+    };
+}
+

--- a/tests/MultiLock.IntegrationTests/PostgreSQLSemaphoreIntegrationTests.cs
+++ b/tests/MultiLock.IntegrationTests/PostgreSQLSemaphoreIntegrationTests.cs
@@ -1,0 +1,311 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.PostgreSQL;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.IntegrationTests;
+
+[Collection("PostgreSQL")]
+public class PostgreSqlSemaphoreIntegrationTests : IAsyncLifetime
+{
+    private static readonly string connectionString =
+        Environment.GetEnvironmentVariable("MULTILOCK_POSTGRES_CONNECTION")
+        ?? "Host=localhost;Database=leaderelection;Username=leaderelection;Password=leaderelection123";
+    private const string schemaName = "public";
+    private readonly ILogger<PostgreSqlSemaphoreProvider> logger;
+
+    // Unique per test-class-instance so parallel test runs and multiple [Fact] methods never share state.
+    private readonly string tableName = $"test_semaphore_{Guid.NewGuid():N}";
+    private readonly string semaphoreName = $"semaphore-{Guid.NewGuid():N}";
+
+    public PostgreSqlSemaphoreIntegrationTests()
+    {
+        ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        logger = loggerFactory.CreateLogger<PostgreSqlSemaphoreProvider>();
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Verify PostgreSQL is available before running tests
+        if (!await IsPostgreSqlAvailableAsync())
+            throw new InvalidOperationException("PostgreSQL is not available. Make sure PostgreSQL is running on localhost:5432");
+    }
+
+    public async Task DisposeAsync()
+    {
+        // Drop the per-test table so the database stays clean across runs.
+        try
+        {
+            await using var connection = new NpgsqlConnection(connectionString);
+            await connection.OpenAsync();
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"""DROP TABLE IF EXISTS "{schemaName}"."{tableName}" """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // Best-effort cleanup — don't fail the test on teardown errors.
+        }
+    }
+
+    [Fact]
+    public async Task HealthCheck_WithPostgreSQL_ShouldReturnTrue()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+
+        // Act
+        bool isHealthy = await provider.HealthCheckAsync();
+
+        // Assert
+        isHealthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "test", "value" } };
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync(
+            semaphoreName,
+            "holder-1",
+            3,
+            metadata,
+            TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 2;
+
+        // Fill the semaphore
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5));
+        await provider.TryAcquireAsync(semaphoreName, "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync(semaphoreName, "holder-3", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderAlreadyHasSlot_ShouldRenew()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Act - try to acquire again with same holder
+        bool acquired = await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+        int count = await provider.GetCurrentCountAsync(semaphoreName, TimeSpan.FromMinutes(5));
+        count.ShouldBe(1); // Should still be 1, not 2
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_ShouldAllowNewHolder()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 1;
+
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Act
+        await provider.ReleaseAsync(semaphoreName, "holder-1");
+        bool acquired = await provider.TryAcquireAsync(semaphoreName, "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenHolding_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        var updatedMetadata = new Dictionary<string, string> { { "key", "updated-value" } };
+
+        // Act
+        bool updated = await provider.UpdateHeartbeatAsync(semaphoreName, "holder-1", updatedMetadata);
+
+        // Assert
+        updated.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenNotHolding_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool updated = await provider.UpdateHeartbeatAsync(semaphoreName, "holder-1", metadata);
+
+        // Assert
+        updated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_ShouldReturnCorrectCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata, TimeSpan.FromMinutes(5));
+        await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata, TimeSpan.FromMinutes(5));
+
+        // Act
+        int count = await provider.GetCurrentCountAsync(semaphoreName, TimeSpan.FromMinutes(5));
+
+        // Assert
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GetHoldersAsync_ShouldReturnAllHolders()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+        var metadata1 = new Dictionary<string, string> { { "holder", "1" } };
+        var metadata2 = new Dictionary<string, string> { { "holder", "2" } };
+
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata1, TimeSpan.FromMinutes(5));
+        await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata2, TimeSpan.FromMinutes(5));
+
+        // Act
+        IReadOnlyList<SemaphoreHolder> holders = await provider.GetHoldersAsync(semaphoreName);
+
+        // Assert
+        holders.Count.ShouldBe(2);
+        holders.ShouldContain(h => h.HolderId == "holder-1");
+        holders.ShouldContain(h => h.HolderId == "holder-2");
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_ShouldReturnCorrectStatus()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool isHoldingBefore = await provider.IsHoldingAsync(semaphoreName, "holder-1");
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+        bool isHoldingAfter = await provider.IsHoldingAsync(semaphoreName, "holder-1");
+
+        // Assert
+        isHoldingBefore.ShouldBeFalse();
+        isHoldingAfter.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ConcurrentAcquire_ShouldRespectMaxCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 3;
+        const int holderCount = 10;
+
+        // Create a single provider to ensure table is created before concurrent access
+        using var mainProvider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+
+        // Initialize the table by doing a health check
+        await mainProvider.HealthCheckAsync();
+
+        var tasks = new List<Task<bool>>();
+
+        // Act - try to acquire with many holders concurrently using separate providers
+        for (int i = 0; i < holderCount; i++)
+        {
+            int holderId = i;
+            tasks.Add(Task.Run(async () =>
+            {
+                using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+                return await provider.TryAcquireAsync(
+                    semaphoreName,
+                    $"holder-{holderId}",
+                    maxCount,
+                    metadata,
+                    TimeSpan.FromMinutes(5));
+            }));
+        }
+
+        bool[] results = await Task.WhenAll(tasks);
+
+        // Assert - exactly maxCount slots should have been acquired.
+        // The provider uses pg_advisory_xact_lock under ReadCommitted, which serialises
+        // per-semaphore acquisitions and prevents over-admission.
+        // With holderCount >> maxCount all slots should be filled.
+        int successCount = results.Count(r => r);
+        successCount.ShouldBe(maxCount);
+
+        // Verify that the provider's view of the count matches what the acquisitions returned.
+        int reportedCount = await mainProvider.GetCurrentCountAsync(semaphoreName, TimeSpan.FromMinutes(5));
+        reportedCount.ShouldBe(maxCount);
+    }
+
+    private PostgreSqlSemaphoreOptions CreateOptions() => new()
+    {
+        ConnectionString = connectionString,
+        TableName = tableName,
+        SchemaName = schemaName,
+        AutoCreateTable = true,
+        CommandTimeoutSeconds = 30
+    };
+
+    private async Task<bool> IsPostgreSqlAvailableAsync()
+    {
+        try
+        {
+            var options = new PostgreSqlSemaphoreOptions
+            {
+                ConnectionString = connectionString,
+                TableName = "health_check"
+            };
+
+            using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
+            return await provider.HealthCheckAsync();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+

--- a/tests/MultiLock.IntegrationTests/PostgreSQLSemaphoreIntegrationTests.cs
+++ b/tests/MultiLock.IntegrationTests/PostgreSQLSemaphoreIntegrationTests.cs
@@ -94,8 +94,8 @@ public class PostgreSqlSemaphoreIntegrationTests : IAsyncLifetime
         const int maxCount = 2;
 
         // Fill the semaphore
-        await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5));
-        await provider.TryAcquireAsync(semaphoreName, "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue();
+        (await provider.TryAcquireAsync(semaphoreName, "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue();
 
         // Act
         bool acquired = await provider.TryAcquireAsync(semaphoreName, "holder-3", maxCount, metadata, TimeSpan.FromMinutes(5));
@@ -112,7 +112,7 @@ public class PostgreSqlSemaphoreIntegrationTests : IAsyncLifetime
         using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
         var metadata = new Dictionary<string, string> { { "key", "value" } };
 
-        await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue();
 
         // Act - try to acquire again with same holder
         bool acquired = await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
@@ -132,7 +132,7 @@ public class PostgreSqlSemaphoreIntegrationTests : IAsyncLifetime
         var metadata = new Dictionary<string, string>();
         const int maxCount = 1;
 
-        await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5));
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue();
 
         // Act
         await provider.ReleaseAsync(semaphoreName, "holder-1");
@@ -150,7 +150,7 @@ public class PostgreSqlSemaphoreIntegrationTests : IAsyncLifetime
         using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
         var metadata = new Dictionary<string, string> { { "key", "value" } };
 
-        await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue();
 
         var updatedMetadata = new Dictionary<string, string> { { "key", "updated-value" } };
 
@@ -184,8 +184,8 @@ public class PostgreSqlSemaphoreIntegrationTests : IAsyncLifetime
         using var provider = new PostgreSqlSemaphoreProvider(Options.Create(options), logger);
         var metadata = new Dictionary<string, string>();
 
-        await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata, TimeSpan.FromMinutes(5));
-        await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata, TimeSpan.FromMinutes(5));
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue();
+        (await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue();
 
         // Act
         int count = await provider.GetCurrentCountAsync(semaphoreName, TimeSpan.FromMinutes(5));
@@ -203,8 +203,8 @@ public class PostgreSqlSemaphoreIntegrationTests : IAsyncLifetime
         var metadata1 = new Dictionary<string, string> { { "holder", "1" } };
         var metadata2 = new Dictionary<string, string> { { "holder", "2" } };
 
-        await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata1, TimeSpan.FromMinutes(5));
-        await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata2, TimeSpan.FromMinutes(5));
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata1, TimeSpan.FromMinutes(5))).ShouldBeTrue();
+        (await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata2, TimeSpan.FromMinutes(5))).ShouldBeTrue();
 
         // Act
         IReadOnlyList<SemaphoreHolder> holders = await provider.GetHoldersAsync(semaphoreName);
@@ -225,7 +225,7 @@ public class PostgreSqlSemaphoreIntegrationTests : IAsyncLifetime
 
         // Act
         bool isHoldingBefore = await provider.IsHoldingAsync(semaphoreName, "holder-1");
-        await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue();
         bool isHoldingAfter = await provider.IsHoldingAsync(semaphoreName, "holder-1");
 
         // Assert

--- a/tests/MultiLock.IntegrationTests/RedisSemaphoreIntegrationTests.cs
+++ b/tests/MultiLock.IntegrationTests/RedisSemaphoreIntegrationTests.cs
@@ -1,0 +1,267 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.Redis;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.IntegrationTests;
+
+[Collection("Redis")]
+public class RedisSemaphoreIntegrationTests : IAsyncLifetime
+{
+    private const string ConnectionString = "localhost:6379";
+    private readonly ILogger<RedisSemaphoreProvider> logger;
+    private readonly string keyPrefix;
+
+    public RedisSemaphoreIntegrationTests()
+    {
+        ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        logger = loggerFactory.CreateLogger<RedisSemaphoreProvider>();
+        keyPrefix = $"test-semaphore-{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        if (!await IsRedisAvailableAsync())
+            throw new InvalidOperationException("Redis is not available. Make sure Redis is running on localhost:6379");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task HealthCheck_WithRedis_ShouldReturnTrue()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+
+        // Act
+        bool isHealthy = await provider.HealthCheckAsync();
+
+        // Assert
+        isHealthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "test", "value" } };
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 2;
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire");
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-3", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderAlreadyHasSlot_ShouldRenew()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("initial acquire should succeed");
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+        count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_ShouldAllowNewHolder()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 1;
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+
+        // Act
+        await provider.ReleaseAsync("test-semaphore", "holder-1");
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenHolding_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+
+        // Act
+        bool updated = await provider.UpdateHeartbeatAsync("test-semaphore", "holder-1", metadata);
+
+        // Assert
+        updated.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenNotHolding_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool updated = await provider.UpdateHeartbeatAsync("test-semaphore", "holder-1", metadata);
+
+        // Assert
+        updated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_ShouldReturnCorrectCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-2", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire");
+
+        // Act
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+
+        // Assert
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GetHoldersAsync_ShouldReturnAllHolders()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        var metadata1 = new Dictionary<string, string> { { "holder", "1" } };
+        var metadata2 = new Dictionary<string, string> { { "holder", "2" } };
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 5, metadata1, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-2", 5, metadata2, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire");
+
+        // Act
+        IReadOnlyList<SemaphoreHolder> holders = await provider.GetHoldersAsync("test-semaphore");
+
+        // Assert
+        holders.Count.ShouldBe(2);
+        holders.ShouldContain(h => h.HolderId == "holder-1");
+        holders.ShouldContain(h => h.HolderId == "holder-2");
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_ShouldReturnCorrectStatus()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool isHoldingBefore = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+        await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+        bool isHoldingAfter = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+
+        // Assert
+        isHoldingBefore.ShouldBeFalse();
+        isHoldingAfter.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ConcurrentAcquire_ShouldRespectMaxCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 3;
+        const int holderCount = 10;
+
+        var tasks = new List<Task<bool>>();
+
+        // Act
+        for (int i = 0; i < holderCount; i++)
+        {
+            int holderId = i;
+            tasks.Add(Task.Run(async () =>
+            {
+                using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+                return await provider.TryAcquireAsync(
+                    "test-semaphore",
+                    $"holder-{holderId}",
+                    maxCount,
+                    metadata,
+                    TimeSpan.FromMinutes(5));
+            }));
+        }
+
+        bool[] results = await Task.WhenAll(tasks);
+
+        // Assert - exactly maxCount slots should have been acquired (the Lua script is atomic,
+        // so neither over- nor under-admission is possible).
+        int successCount = results.Count(r => r);
+        successCount.ShouldBe(maxCount);
+
+        // Verify the provider's reported count matches the atomic admission result.
+        using var verificationProvider = new RedisSemaphoreProvider(Options.Create(options), logger);
+        int reportedCount = await verificationProvider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+        reportedCount.ShouldBe(maxCount);
+    }
+
+    private RedisSemaphoreOptions CreateOptions() => new()
+    {
+        ConnectionString = ConnectionString,
+        KeyPrefix = keyPrefix,
+        Database = 0
+    };
+
+    private async Task<bool> IsRedisAvailableAsync()
+    {
+        try
+        {
+            var options = CreateOptions();
+            using var provider = new RedisSemaphoreProvider(Options.Create(options), logger);
+            return await provider.HealthCheckAsync();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+

--- a/tests/MultiLock.IntegrationTests/SqlServerSemaphoreIntegrationTests.cs
+++ b/tests/MultiLock.IntegrationTests/SqlServerSemaphoreIntegrationTests.cs
@@ -1,0 +1,298 @@
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.SqlServer;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.IntegrationTests;
+
+[Collection("SqlServer")]
+public class SqlServerSemaphoreIntegrationTests : IAsyncLifetime
+{
+    private static readonly string ConnectionString =
+        Environment.GetEnvironmentVariable("MULTILOCK_SQLSERVER_CONNECTION")
+        ?? "Server=localhost,1433;Database=leaderelection;User Id=sa;Password=LeaderElection123!;TrustServerCertificate=True";
+    private const string SchemaName = "dbo";
+    private readonly ILoggerFactory loggerFactory;
+    private readonly ILogger<SqlServerSemaphoreProvider> logger;
+
+    // Unique per test-class-instance so parallel test runs and multiple [Fact] methods never share state.
+    private readonly string tableName = $"test_semaphore_{Guid.NewGuid():N}";
+    private readonly string semaphoreName = $"semaphore-{Guid.NewGuid():N}";
+
+    public SqlServerSemaphoreIntegrationTests()
+    {
+        loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        logger = loggerFactory.CreateLogger<SqlServerSemaphoreProvider>();
+    }
+
+    public async Task InitializeAsync()
+    {
+        if (!await IsSqlServerAvailableAsync())
+            throw new InvalidOperationException("SQL Server is not available. Make sure SQL Server is running on localhost:1433");
+    }
+
+    public async Task DisposeAsync()
+    {
+        // Drop the per-test table so the database stays clean across runs.
+        try
+        {
+            await using var connection = new SqlConnection(ConnectionString);
+            await connection.OpenAsync();
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"IF OBJECT_ID(N'[{SchemaName}].[{tableName}]', N'U') IS NOT NULL DROP TABLE [{SchemaName}].[{tableName}]";
+            await cmd.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // Best-effort cleanup — don't fail the test on teardown errors.
+        }
+
+        loggerFactory.Dispose();
+    }
+
+    [Fact]
+    public async Task HealthCheck_WithSqlServer_ShouldReturnTrue()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+
+        // Act
+        bool isHealthy = await provider.HealthCheckAsync();
+
+        // Assert
+        isHealthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "test", "value" } };
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 2;
+
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire a slot");
+        (await provider.TryAcquireAsync(semaphoreName, "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire a slot");
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync(semaphoreName, "holder-3", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderAlreadyHasSlot_ShouldRenew()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire the initial slot");
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+        int count = await provider.GetCurrentCountAsync(semaphoreName, TimeSpan.FromMinutes(5));
+        count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_ShouldAllowNewHolder()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 1;
+
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire the initial slot");
+
+        // Act
+        await provider.ReleaseAsync(semaphoreName, "holder-1");
+        bool acquired = await provider.TryAcquireAsync(semaphoreName, "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenHolding_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire a slot");
+
+        // Act
+        bool updated = await provider.UpdateHeartbeatAsync(semaphoreName, "holder-1", metadata);
+
+        // Assert
+        updated.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenNotHolding_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool updated = await provider.UpdateHeartbeatAsync(semaphoreName, "holder-1", metadata);
+
+        // Assert
+        updated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_ShouldReturnCorrectCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire a slot");
+        (await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire a slot");
+
+        // Act
+        int count = await provider.GetCurrentCountAsync(semaphoreName, TimeSpan.FromMinutes(5));
+
+        // Assert
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GetHoldersAsync_ShouldReturnAllHolders()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        var metadata1 = new Dictionary<string, string> { { "holder", "1" } };
+        var metadata2 = new Dictionary<string, string> { { "holder", "2" } };
+
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata1, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire a slot");
+        (await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata2, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire a slot");
+
+        // Act
+        IReadOnlyList<SemaphoreHolder> holders = await provider.GetHoldersAsync(semaphoreName);
+
+        // Assert
+        holders.Count.ShouldBe(2);
+        holders.ShouldContain(h => h.HolderId == "holder-1");
+        holders.ShouldContain(h => h.HolderId == "holder-2");
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_ShouldReturnCorrectStatus()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool isHoldingBefore = await provider.IsHoldingAsync(semaphoreName, "holder-1");
+        (await provider.TryAcquireAsync(semaphoreName, "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire a slot");
+        bool isHoldingAfter = await provider.IsHoldingAsync(semaphoreName, "holder-1");
+
+        // Assert
+        isHoldingBefore.ShouldBeFalse();
+        isHoldingAfter.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ConcurrentAcquire_ShouldRespectMaxCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 3;
+        const int holderCount = 10;
+
+        // Create a single provider to ensure table is created before concurrent access
+        using var mainProvider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+        await mainProvider.HealthCheckAsync();
+
+        var tasks = new List<Task<bool>>();
+
+        // Act
+        for (int i = 0; i < holderCount; i++)
+        {
+            int holderId = i;
+            tasks.Add(Task.Run(async () =>
+            {
+                using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+                return await provider.TryAcquireAsync(
+                    semaphoreName,
+                    $"holder-{holderId}",
+                    maxCount,
+                    metadata,
+                    TimeSpan.FromMinutes(5));
+            }));
+        }
+
+        bool[] results = await Task.WhenAll(tasks);
+
+        // Assert - exactly maxCount slots should have been acquired.
+        // sp_getapplock with Exclusive mode under ReadCommitted serialises per-semaphore
+        // acquisitions and prevents over-admission.
+        // With holderCount >> maxCount all slots must be filled.
+        int successCount = results.Count(r => r);
+        successCount.ShouldBe(maxCount);
+
+        // Verify that the provider's view of the count matches what the acquisitions returned.
+        int reportedCount = await mainProvider.GetCurrentCountAsync(semaphoreName, TimeSpan.FromMinutes(5));
+        reportedCount.ShouldBe(maxCount);
+    }
+
+    private SqlServerSemaphoreOptions CreateOptions() => new()
+    {
+        ConnectionString = ConnectionString,
+        TableName = tableName,
+        SchemaName = SchemaName,
+        AutoCreateTable = true,
+        CommandTimeoutSeconds = 30
+    };
+
+    private async Task<bool> IsSqlServerAvailableAsync()
+    {
+        try
+        {
+            var options = CreateOptions();
+            using var provider = new SqlServerSemaphoreProvider(Options.Create(options), logger);
+            return await provider.HealthCheckAsync();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+

--- a/tests/MultiLock.IntegrationTests/ZooKeeperSemaphoreIntegrationTests.cs
+++ b/tests/MultiLock.IntegrationTests/ZooKeeperSemaphoreIntegrationTests.cs
@@ -1,0 +1,181 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.ZooKeeper;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.IntegrationTests;
+
+[Collection("ZooKeeper")]
+public class ZooKeeperSemaphoreIntegrationTests : IAsyncLifetime
+{
+    private const string ConnectionString = "localhost:2181";
+    private readonly ILoggerFactory loggerFactory;
+    private readonly ILogger<ZooKeeperSemaphoreProvider> logger;
+    private readonly string rootPath;
+
+    public ZooKeeperSemaphoreIntegrationTests()
+    {
+        loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        logger = loggerFactory.CreateLogger<ZooKeeperSemaphoreProvider>();
+        rootPath = $"/test-semaphore-{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        if (!await IsZooKeeperAvailableAsync())
+            throw new InvalidOperationException("ZooKeeper is not available. Make sure ZooKeeper is running on localhost:2181");
+    }
+
+    public Task DisposeAsync()
+    {
+        loggerFactory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task HealthCheck_WithZooKeeper_ShouldReturnTrue()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ZooKeeperSemaphoreProvider(Options.Create(options), logger);
+
+        // Act
+        bool isHealthy = await provider.HealthCheckAsync();
+
+        // Assert
+        isHealthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ZooKeeperSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "test", "value" } };
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ZooKeeperSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 2;
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire");
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-3", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderAlreadyHasSlot_ShouldRenew()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ZooKeeperSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("initial acquire should succeed");
+
+        // Act
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+        count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_ShouldAllowNewHolder()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ZooKeeperSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+        const int maxCount = 1;
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", maxCount, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+
+        // Act
+        await provider.ReleaseAsync("test-semaphore", "holder-1");
+        bool acquired = await provider.TryAcquireAsync("test-semaphore", "holder-2", maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        // Assert
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_ShouldReturnCorrectCount()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ZooKeeperSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-1 should acquire");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-2", 5, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("holder-2 should acquire");
+
+        // Act
+        int count = await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromMinutes(5));
+
+        // Assert
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_ShouldReturnCorrectStatus()
+    {
+        // Arrange
+        var options = CreateOptions();
+        using var provider = new ZooKeeperSemaphoreProvider(Options.Create(options), logger);
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool isHoldingBefore = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+        (await provider.TryAcquireAsync("test-semaphore", "holder-1", 3, metadata, TimeSpan.FromMinutes(5))).ShouldBeTrue("should acquire");
+        bool isHoldingAfter = await provider.IsHoldingAsync("test-semaphore", "holder-1");
+
+        // Assert
+        isHoldingBefore.ShouldBeFalse();
+        isHoldingAfter.ShouldBeTrue();
+    }
+
+    private ZooKeeperSemaphoreOptions CreateOptions() => new()
+    {
+        ConnectionString = ConnectionString,
+        RootPath = rootPath,
+        SessionTimeout = TimeSpan.FromSeconds(30),
+        ConnectionTimeout = TimeSpan.FromSeconds(10),
+        AutoCreateRootPath = true
+    };
+
+    private async Task<bool> IsZooKeeperAvailableAsync()
+    {
+        try
+        {
+            var options = CreateOptions();
+            using var provider = new ZooKeeperSemaphoreProvider(Options.Create(options), logger);
+            return await provider.HealthCheckAsync();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+

--- a/tests/MultiLock.Tests/FileSystemSemaphoreOptionsTests.cs
+++ b/tests/MultiLock.Tests/FileSystemSemaphoreOptionsTests.cs
@@ -1,0 +1,60 @@
+using MultiLock.FileSystem;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+public class FileSystemSemaphoreOptionsTests
+{
+    [Fact]
+    public void Validate_WithDefaultOptions_ShouldNotThrow()
+    {
+        var options = new FileSystemSemaphoreOptions();
+        Should.NotThrow(() => options.Validate());
+    }
+
+    [Fact]
+    public void Validate_WithValidCustomOptions_ShouldNotThrow()
+    {
+        var options = new FileSystemSemaphoreOptions
+        {
+            DirectoryPath = Path.Combine(Path.GetTempPath(), "my-semaphores"),
+            FileExtension = ".lock",
+            AutoCreateDirectory = false
+        };
+        Should.NotThrow(() => options.Validate());
+    }
+
+    [Fact]
+    public void Validate_WithEmptyDirectoryPath_ShouldThrow()
+    {
+        var options = new FileSystemSemaphoreOptions { DirectoryPath = "" };
+        ArgumentException ex = Should.Throw<ArgumentException>(() => options.Validate());
+        ex.ParamName.ShouldBe("DirectoryPath");
+    }
+
+    [Fact]
+    public void Validate_WithWhitespaceDirectoryPath_ShouldThrow()
+    {
+        var options = new FileSystemSemaphoreOptions { DirectoryPath = "   " };
+        ArgumentException ex = Should.Throw<ArgumentException>(() => options.Validate());
+        ex.ParamName.ShouldBe("DirectoryPath");
+    }
+
+    [Fact]
+    public void Validate_WithEmptyFileExtension_ShouldThrow()
+    {
+        var options = new FileSystemSemaphoreOptions { FileExtension = "" };
+        ArgumentException ex = Should.Throw<ArgumentException>(() => options.Validate());
+        ex.ParamName.ShouldBe("FileExtension");
+    }
+
+    [Fact]
+    public void Validate_WithWhitespaceFileExtension_ShouldThrow()
+    {
+        var options = new FileSystemSemaphoreOptions { FileExtension = "  " };
+        ArgumentException ex = Should.Throw<ArgumentException>(() => options.Validate());
+        ex.ParamName.ShouldBe("FileExtension");
+    }
+}
+

--- a/tests/MultiLock.Tests/FileSystemSemaphoreProviderTests.cs
+++ b/tests/MultiLock.Tests/FileSystemSemaphoreProviderTests.cs
@@ -1,0 +1,206 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.FileSystem;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+public class FileSystemSemaphoreProviderTests : IDisposable
+{
+    private readonly FileSystemSemaphoreProvider provider;
+    private readonly ILoggerFactory loggerFactory;
+    private readonly string directoryPath;
+
+    public FileSystemSemaphoreProviderTests()
+    {
+        loggerFactory = new LoggerFactory();
+        directoryPath = Path.Combine(Path.GetTempPath(), $"ml-test-{Guid.NewGuid():N}");
+        provider = CreateProvider(directoryPath);
+    }
+
+    public void Dispose()
+    {
+        provider.Dispose();
+        loggerFactory.Dispose();
+        if (Directory.Exists(directoryPath))
+            Directory.Delete(directoryPath, true);
+    }
+
+    private FileSystemSemaphoreProvider CreateProvider(string dir) =>
+        new(Options.Create(new FileSystemSemaphoreOptions { DirectoryPath = dir }),
+            loggerFactory.CreateLogger<FileSystemSemaphoreProvider>());
+
+    private static readonly Dictionary<string, string> NoMeta = [];
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        bool result = await provider.TryAcquireAsync("sem1", "h1", 3, NoMeta, TimeSpan.FromMinutes(5));
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        await provider.TryAcquireAsync("sem1", "h1", 1, NoMeta, TimeSpan.FromMinutes(5));
+        bool result = await provider.TryAcquireAsync("sem1", "h2", 1, NoMeta, TimeSpan.FromMinutes(5));
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderAlreadyHasSlot_ShouldRenewAndNotDoubleCount()
+    {
+        await provider.TryAcquireAsync("sem1", "h1", 3, NoMeta, TimeSpan.FromMinutes(5));
+        bool result = await provider.TryAcquireAsync("sem1", "h1", 3, NoMeta, TimeSpan.FromMinutes(5));
+        result.ShouldBeTrue();
+        int count = await provider.GetCurrentCountAsync("sem1", TimeSpan.FromMinutes(5));
+        count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_WhenHolding_ShouldRelease()
+    {
+        await provider.TryAcquireAsync("sem1", "h1", 3, NoMeta, TimeSpan.FromMinutes(5));
+        await provider.ReleaseAsync("sem1", "h1");
+        bool holding = await provider.IsHoldingAsync("sem1", "h1");
+        holding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_WhenNotHolding_ShouldNotThrow()
+    {
+        await Should.NotThrowAsync(() => provider.ReleaseAsync("sem1", "h1"));
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenHolding_ShouldReturnTrue()
+    {
+        await provider.TryAcquireAsync("sem1", "h1", 3, NoMeta, TimeSpan.FromMinutes(5));
+        bool result = await provider.UpdateHeartbeatAsync("sem1", "h1", new Dictionary<string, string> { { "k", "v" } });
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenNotHolding_ShouldReturnFalse()
+    {
+        bool result = await provider.UpdateHeartbeatAsync("sem1", "h1", NoMeta);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_ShouldReturnCorrectCount()
+    {
+        await provider.TryAcquireAsync("sem1", "h1", 5, NoMeta, TimeSpan.FromMinutes(5));
+        await provider.TryAcquireAsync("sem1", "h2", 5, NoMeta, TimeSpan.FromMinutes(5));
+        int count = await provider.GetCurrentCountAsync("sem1", TimeSpan.FromMinutes(5));
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GetHoldersAsync_ShouldReturnAllActiveHolders()
+    {
+        await provider.TryAcquireAsync("sem1", "h1", 5, NoMeta, TimeSpan.FromMinutes(5));
+        await provider.TryAcquireAsync("sem1", "h2", 5, NoMeta, TimeSpan.FromMinutes(5));
+        IReadOnlyList<SemaphoreHolder> holders = await provider.GetHoldersAsync("sem1");
+        holders.Count.ShouldBe(2);
+        holders.ShouldContain(h => h.HolderId == "h1");
+        holders.ShouldContain(h => h.HolderId == "h2");
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_WhenHolding_ShouldReturnTrue()
+    {
+        await provider.TryAcquireAsync("sem1", "h1", 3, NoMeta, TimeSpan.FromMinutes(5));
+        bool holding = await provider.IsHoldingAsync("sem1", "h1");
+        holding.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_WhenNotHolding_ShouldReturnFalse()
+    {
+        bool holding = await provider.IsHoldingAsync("sem1", "h1");
+        holding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HealthCheckAsync_ShouldReturnTrue()
+    {
+        bool healthy = await provider.HealthCheckAsync();
+        healthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Dispose_ShouldNotThrow()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"ml-d-{Guid.NewGuid():N}");
+        var p = CreateProvider(tempDir);
+        try
+        {
+            Should.NotThrow(() => p.Dispose());
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task MethodsAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"ml-d-{Guid.NewGuid():N}");
+        var p = CreateProvider(tempDir);
+        try
+        {
+            p.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => p.TryAcquireAsync("s", "h", 1, NoMeta, TimeSpan.FromMinutes(1)));
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => p.ReleaseAsync("s", "h"));
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => p.UpdateHeartbeatAsync("s", "h", NoMeta));
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => p.GetCurrentCountAsync("s", TimeSpan.FromMinutes(1)));
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => p.GetHoldersAsync("s"));
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => p.IsHoldingAsync("s", "h"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithInvalidSemaphoreName_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.TryAcquireAsync("invalid name!", "h1", 1, NoMeta, TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithNullHolderId_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.TryAcquireAsync("sem1", null!, 1, NoMeta, TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithZeroMaxCount_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.TryAcquireAsync("sem1", "h1", 0, NoMeta, TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithZeroSlotTimeout_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.TryAcquireAsync("sem1", "h1", 1, NoMeta, TimeSpan.Zero));
+    }
+}
+

--- a/tests/MultiLock.Tests/FileSystemSemaphoreProviderTests.cs
+++ b/tests/MultiLock.Tests/FileSystemSemaphoreProviderTests.cs
@@ -202,5 +202,54 @@ public class FileSystemSemaphoreProviderTests : IDisposable
         await Assert.ThrowsAsync<ArgumentException>(
             () => provider.TryAcquireAsync("sem1", "h1", 1, NoMeta, TimeSpan.Zero));
     }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithCorruptHolderFile_DoesNotConsumeCapacityAndCleansItUp()
+    {
+        const string sem = "sem1";
+        const string ext = ".holder";
+
+        // Plant a corrupt holder file directly in the semaphore directory, simulating a file left
+        // behind by a crash mid-write (the pre-fix failure mode that could under-count live holders
+        // and let the count exceed maxCount).
+        string semDir = Path.Combine(directoryPath, sem);
+        Directory.CreateDirectory(semDir);
+        string corruptFile = Path.Combine(semDir, $"corrupt{ext}");
+        await File.WriteAllTextAsync(corruptFile, "{ this is not valid json");
+
+        // A corrupt/unreadable file must never be counted as an active holder.
+        int countBefore = await provider.GetCurrentCountAsync(sem, TimeSpan.FromMinutes(5));
+        countBefore.ShouldBe(0);
+
+        // Fill the semaphore to capacity. The corrupt file must not have consumed a slot...
+        (await provider.TryAcquireAsync(sem, "h1", 2, NoMeta, TimeSpan.FromMinutes(5))).ShouldBeTrue();
+        (await provider.TryAcquireAsync(sem, "h2", 2, NoMeta, TimeSpan.FromMinutes(5))).ShouldBeTrue();
+
+        // ...and must not let the live count exceed maxCount.
+        (await provider.TryAcquireAsync(sem, "h3", 2, NoMeta, TimeSpan.FromMinutes(5))).ShouldBeFalse();
+
+        int count = await provider.GetCurrentCountAsync(sem, TimeSpan.FromMinutes(5));
+        count.ShouldBe(2);
+
+        // Cleanup (run on each acquire) should have removed the corrupt file so it cannot accumulate.
+        File.Exists(corruptFile).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WritesAtomically_LeavesNoTempFilesBehind()
+    {
+        const string sem = "sem1";
+        const string ext = ".holder";
+
+        await provider.TryAcquireAsync(sem, "h1", 3, NoMeta, TimeSpan.FromMinutes(5));
+        await provider.UpdateHeartbeatAsync(sem, "h1", new Dictionary<string, string> { { "k", "v" } });
+
+        string semDir = Path.Combine(directoryPath, sem);
+
+        // Atomic writes go through a uniquely named ".tmp-*" file that is moved into place; none must
+        // remain after the operation completes, and exactly one valid holder file should exist.
+        Directory.GetFiles(semDir, "*.tmp-*").ShouldBeEmpty();
+        Directory.GetFiles(semDir, $"*{ext}").Length.ShouldBe(1);
+    }
 }
 

--- a/tests/MultiLock.Tests/FileSystemServiceCollectionExtensionsTests.cs
+++ b/tests/MultiLock.Tests/FileSystemServiceCollectionExtensionsTests.cs
@@ -154,5 +154,132 @@ public class FileSystemServiceCollectionExtensionsTests
         leaderElectionProvider.ShouldNotBeNull();
         leaderElectionProvider.ShouldBeOfType<FileSystemLeaderElectionProvider>();
     }
+
+    // AddFileSystemSemaphore tests
+
+    [Fact]
+    public void AddFileSystemSemaphore_WithNullServices_ShouldThrowArgumentNullException()
+    {
+        IServiceCollection? services = null;
+        Should.Throw<ArgumentNullException>(() =>
+            services!.AddFileSystemSemaphore(options => options.DirectoryPath = "test"))
+            .ParamName.ShouldBe("services");
+    }
+
+    [Fact]
+    public void AddFileSystemSemaphore_WithConfigureOptions_ShouldRegisterProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        IServiceCollection result = services.AddFileSystemSemaphore(
+            options => options.DirectoryPath = Path.Combine(Path.GetTempPath(), "test-semaphore"),
+            semaphoreOptions => semaphoreOptions.SemaphoreName = "test-sem");
+
+        result.ShouldBe(services);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ISemaphoreProvider? semaphoreProvider = provider.GetService<ISemaphoreProvider>();
+        semaphoreProvider.ShouldNotBeNull();
+        semaphoreProvider.ShouldBeOfType<FileSystemSemaphoreProvider>();
+        provider.GetService<ISemaphoreService>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddFileSystemSemaphore_WithConfigureOptionsAndSemaphoreOptions_ShouldSucceed()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        IServiceCollection result = services.AddFileSystemSemaphore(
+            options => options.DirectoryPath = Path.Combine(Path.GetTempPath(), "test-semaphore"),
+            semaphoreOptions =>
+            {
+                semaphoreOptions.SemaphoreName = "my-semaphore";
+                semaphoreOptions.MaxCount = 5;
+            });
+
+        result.ShouldBe(services);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<ISemaphoreService>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddFileSystemSemaphore_WithNullSemaphoreOptions_ShouldSucceed()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // When configureSemaphoreOptions is null, options stay at defaults;
+        // the provider is registered but validation of SemaphoreName is deferred to first use.
+        IServiceCollection result = services.AddFileSystemSemaphore(
+            options => options.DirectoryPath = Path.Combine(Path.GetTempPath(), "test-semaphore"),
+            configureSemaphoreOptions: null);
+
+        result.ShouldBe(services);
+
+        // Only verify the provider itself is registered (the service is lazy-validated)
+        ServiceProvider provider = services.BuildServiceProvider();
+        ISemaphoreProvider? semaphoreProvider = provider.GetService<ISemaphoreProvider>();
+        semaphoreProvider.ShouldNotBeNull();
+        semaphoreProvider.ShouldBeOfType<FileSystemSemaphoreProvider>();
+    }
+
+    [Fact]
+    public void AddFileSystemSemaphore_WithDirectoryPath_ShouldRegisterProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        string directoryPath = Path.Combine(Path.GetTempPath(), "test-semaphore");
+
+        IServiceCollection result = services.AddFileSystemSemaphore(directoryPath);
+
+        result.ShouldBe(services);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ISemaphoreProvider? semaphoreProvider = provider.GetService<ISemaphoreProvider>();
+        semaphoreProvider.ShouldNotBeNull();
+        semaphoreProvider.ShouldBeOfType<FileSystemSemaphoreProvider>();
+    }
+
+    [Fact]
+    public void AddFileSystemSemaphore_WithDirectoryPathAndSemaphoreOptions_ShouldSucceed()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        string directoryPath = Path.Combine(Path.GetTempPath(), "test-semaphore");
+
+        IServiceCollection result = services.AddFileSystemSemaphore(
+            directoryPath,
+            semaphoreOptions =>
+            {
+                semaphoreOptions.SemaphoreName = "test-sem";
+                semaphoreOptions.MaxCount = 3;
+            });
+
+        result.ShouldBe(services);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<ISemaphoreService>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddFileSystemSemaphore_WithDirectoryPathAndNullSemaphoreOptions_ShouldSucceed()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        string directoryPath = Path.Combine(Path.GetTempPath(), "test-semaphore");
+
+        // configureSemaphoreOptions null → provider registered, SemaphoreName validated at first use
+        IServiceCollection result = services.AddFileSystemSemaphore(directoryPath, configureSemaphoreOptions: null);
+
+        result.ShouldBe(services);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ISemaphoreProvider? semaphoreProvider = provider.GetService<ISemaphoreProvider>();
+        semaphoreProvider.ShouldNotBeNull();
+        semaphoreProvider.ShouldBeOfType<FileSystemSemaphoreProvider>();
+    }
 }
 

--- a/tests/MultiLock.Tests/InMemorySemaphoreProviderTests.cs
+++ b/tests/MultiLock.Tests/InMemorySemaphoreProviderTests.cs
@@ -1,0 +1,439 @@
+﻿using Microsoft.Extensions.Logging;
+using MultiLock.InMemory;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+public class InMemorySemaphoreProviderTests : IDisposable
+{
+    private readonly InMemorySemaphoreProvider provider;
+    private readonly ILoggerFactory loggerFactory;
+
+    public InMemorySemaphoreProviderTests()
+    {
+        loggerFactory = new LoggerFactory();
+        ILogger<InMemorySemaphoreProvider> logger = loggerFactory.CreateLogger<InMemorySemaphoreProvider>();
+        provider = new InMemorySemaphoreProvider(logger);
+    }
+
+    public void Dispose()
+    {
+        provider.Dispose();
+        loggerFactory.Dispose();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        const string holderId = "holder-1";
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        // Act
+        bool result = await provider.TryAcquireAsync(semaphoreName, holderId, 3, metadata, slotTimeout);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+        const int maxCount = 2;
+
+        // Fill the semaphore
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, slotTimeout);
+        await provider.TryAcquireAsync(semaphoreName, "holder-2", maxCount, metadata, slotTimeout);
+
+        // Act
+        bool result = await provider.TryAcquireAsync(semaphoreName, "holder-3", maxCount, metadata, slotTimeout);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderAlreadyHasSlot_ShouldRenew()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        const string holderId = "holder-1";
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        await provider.TryAcquireAsync(semaphoreName, holderId, 3, metadata, slotTimeout);
+
+        // Act - try to acquire again with same holder
+        bool result = await provider.TryAcquireAsync(semaphoreName, holderId, 3, metadata, slotTimeout);
+
+        // Assert
+        result.ShouldBeTrue();
+        int count = await provider.GetCurrentCountAsync(semaphoreName, slotTimeout);
+        count.ShouldBe(1); // Should still be 1, not 2
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_WhenHolding_ShouldRelease()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        const string holderId = "holder-1";
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        await provider.TryAcquireAsync(semaphoreName, holderId, 3, metadata, slotTimeout);
+
+        // Act
+        await provider.ReleaseAsync(semaphoreName, holderId);
+
+        // Assert
+        bool isHolding = await provider.IsHoldingAsync(semaphoreName, holderId);
+        isHolding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_WhenNotHolding_ShouldNotThrow()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        const string holderId = "holder-1";
+
+        // Act & Assert - should not throw
+        await provider.ReleaseAsync(semaphoreName, holderId);
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenHolding_ShouldSucceed()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        const string holderId = "holder-1";
+        var metadata = new Dictionary<string, string> { { "key", "value" } };
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        await provider.TryAcquireAsync(semaphoreName, holderId, 3, metadata, slotTimeout);
+
+        var updatedMetadata = new Dictionary<string, string> { { "key", "updated-value" } };
+
+        // Act
+        bool result = await provider.UpdateHeartbeatAsync(semaphoreName, holderId, updatedMetadata);
+
+        // Assert
+        result.ShouldBeTrue();
+        IReadOnlyList<SemaphoreHolder> holders = await provider.GetHoldersAsync(semaphoreName);
+        holders.Count.ShouldBe(1);
+        holders[0].Metadata["key"].ShouldBe("updated-value");
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WhenNotHolding_ShouldFail()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        const string holderId = "holder-1";
+        var metadata = new Dictionary<string, string>();
+
+        // Act
+        bool result = await provider.UpdateHeartbeatAsync(semaphoreName, holderId, metadata);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_ShouldReturnCorrectCount()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata, slotTimeout);
+        await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata, slotTimeout);
+
+        // Act
+        int count = await provider.GetCurrentCountAsync(semaphoreName, slotTimeout);
+
+        // Assert
+        count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_WhenNoHolders_ShouldReturnZero()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+
+        // Act
+        int count = await provider.GetCurrentCountAsync(semaphoreName, TimeSpan.FromMinutes(5));
+
+        // Assert
+        count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetHoldersAsync_ShouldReturnAllHolders()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        var metadata1 = new Dictionary<string, string> { { "holder", "1" } };
+        var metadata2 = new Dictionary<string, string> { { "holder", "2" } };
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", 5, metadata1, slotTimeout);
+        await provider.TryAcquireAsync(semaphoreName, "holder-2", 5, metadata2, slotTimeout);
+
+        // Act
+        IReadOnlyList<SemaphoreHolder> holders = await provider.GetHoldersAsync(semaphoreName);
+
+        // Assert
+        holders.Count.ShouldBe(2);
+        holders.ShouldContain(h => h.HolderId == "holder-1");
+        holders.ShouldContain(h => h.HolderId == "holder-2");
+    }
+
+    [Fact]
+    public async Task GetHoldersAsync_WhenNoHolders_ShouldReturnEmptyList()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+
+        // Act
+        IReadOnlyList<SemaphoreHolder> holders = await provider.GetHoldersAsync(semaphoreName);
+
+        // Assert
+        holders.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_WhenHolding_ShouldReturnTrue()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        const string holderId = "holder-1";
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        await provider.TryAcquireAsync(semaphoreName, holderId, 3, metadata, slotTimeout);
+
+        // Act
+        bool isHolding = await provider.IsHoldingAsync(semaphoreName, holderId);
+
+        // Assert
+        isHolding.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_WhenNotHolding_ShouldReturnFalse()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        const string holderId = "holder-1";
+
+        // Act
+        bool isHolding = await provider.IsHoldingAsync(semaphoreName, holderId);
+
+        // Assert
+        isHolding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HealthCheckAsync_ShouldReturnTrue()
+    {
+        // Act
+        bool isHealthy = await provider.HealthCheckAsync();
+
+        // Assert
+        isHealthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSlotExpired_ShouldAllowNewHolder()
+    {
+        // Arrange
+        const string semaphoreName = "test-semaphore";
+        var metadata = new Dictionary<string, string>();
+        var shortTimeout = TimeSpan.FromMilliseconds(100);
+        const int maxCount = 1;
+
+        // First holder acquires with short timeout
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, shortTimeout);
+
+        // Poll until the slot is considered expired or the deadline is reached.
+        // Using a bounded loop avoids fragile fixed delays that fail on slow CI machines.
+        bool result = false;
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!deadline.Token.IsCancellationRequested)
+        {
+            result = await provider.TryAcquireAsync(semaphoreName, "holder-2", maxCount, metadata, shortTimeout);
+            if (result)
+                break;
+            await Task.Delay(10, deadline.Token).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Dispose_ShouldNotThrow()
+    {
+        // Arrange
+        var testProvider = new InMemorySemaphoreProvider(
+            loggerFactory.CreateLogger<InMemorySemaphoreProvider>());
+
+        // Act & Assert
+        testProvider.Dispose(); // Should not throw
+    }
+
+    [Fact]
+    public void Dispose_MultipleTimes_ShouldNotThrow()
+    {
+        // Arrange
+        var testProvider = new InMemorySemaphoreProvider(
+            loggerFactory.CreateLogger<InMemorySemaphoreProvider>());
+
+        // Act & Assert
+        testProvider.Dispose(); // First dispose
+        testProvider.Dispose(); // Second dispose should not throw
+    }
+
+    [Fact]
+    public async Task MethodsAfterDispose_ShouldThrow()
+    {
+        // Arrange
+        var testProvider = new InMemorySemaphoreProvider(
+            loggerFactory.CreateLogger<InMemorySemaphoreProvider>());
+
+        testProvider.Dispose();
+
+        var metadata = new Dictionary<string, string>();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => testProvider.TryAcquireAsync("test", "holder", 3, metadata, TimeSpan.FromMinutes(1)));
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => testProvider.ReleaseAsync("test", "holder"));
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => testProvider.UpdateHeartbeatAsync("test", "holder", metadata));
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => testProvider.GetCurrentCountAsync("test", TimeSpan.FromMinutes(5)));
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => testProvider.GetHoldersAsync("test"));
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => testProvider.IsHoldingAsync("test", "holder"));
+    }
+
+    // Parameter validation tests
+
+    [Fact]
+    public async Task TryAcquireAsync_WithNullSemaphoreName_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.TryAcquireAsync(null!, "holder", 1, new Dictionary<string, string>(), TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithEmptySemaphoreName_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.TryAcquireAsync("", "holder", 1, new Dictionary<string, string>(), TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithNullHolderId_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.TryAcquireAsync("sem", null!, 1, new Dictionary<string, string>(), TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithInvalidMaxCount_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.TryAcquireAsync("sem", "h", 0, new Dictionary<string, string>(), TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithZeroSlotTimeout_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.TryAcquireAsync("sem", "h", 1, new Dictionary<string, string>(), TimeSpan.Zero));
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_WithNullSemaphoreName_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.ReleaseAsync(null!, "holder"));
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_WithNullHolderId_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.ReleaseAsync("sem", null!));
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WithNullSemaphoreName_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.UpdateHeartbeatAsync(null!, "holder", new Dictionary<string, string>()));
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WithNullHolderId_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.UpdateHeartbeatAsync("sem", null!, new Dictionary<string, string>()));
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_WithNullSemaphoreName_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.GetCurrentCountAsync(null!, TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_WithInvalidSlotTimeout_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.GetCurrentCountAsync("sem", TimeSpan.Zero));
+    }
+
+    [Fact]
+    public async Task GetHoldersAsync_WithNullSemaphoreName_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.GetHoldersAsync(null!));
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_WithNullSemaphoreName_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.IsHoldingAsync(null!, "holder"));
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_WithNullHolderId_ShouldThrow()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.IsHoldingAsync("sem", null!));
+    }
+}
+

--- a/tests/MultiLock.Tests/InMemorySemaphoreProviderTests.cs
+++ b/tests/MultiLock.Tests/InMemorySemaphoreProviderTests.cs
@@ -275,7 +275,15 @@ public class InMemorySemaphoreProviderTests : IDisposable
             result = await provider.TryAcquireAsync(semaphoreName, "holder-2", maxCount, metadata, shortTimeout);
             if (result)
                 break;
-            await Task.Delay(10, deadline.Token).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+
+            try
+            {
+                await Task.Delay(10, deadline.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
         }
 
         // Assert

--- a/tests/MultiLock.Tests/InMemoryServiceCollectionExtensionsTests.cs
+++ b/tests/MultiLock.Tests/InMemoryServiceCollectionExtensionsTests.cs
@@ -101,5 +101,60 @@ public class InMemoryServiceCollectionExtensionsTests
         leaderElectionProvider.ShouldNotBeNull();
         leaderElectionProvider.ShouldBeOfType<InMemoryLeaderElectionProvider>();
     }
+
+    // AddInMemorySemaphore tests
+
+    [Fact]
+    public void AddInMemorySemaphore_WithNullServices_ShouldThrowArgumentNullException()
+    {
+        IServiceCollection? services = null;
+        Should.Throw<ArgumentNullException>(() => services!.AddInMemorySemaphore())
+            .ParamName.ShouldBe("services");
+    }
+
+    [Fact]
+    public void AddInMemorySemaphore_WithValidServices_ShouldRegisterProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddInMemorySemaphore(o => o.SemaphoreName = "test-sem");
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ISemaphoreProvider? semaphoreProvider = provider.GetService<ISemaphoreProvider>();
+        semaphoreProvider.ShouldNotBeNull();
+        semaphoreProvider.ShouldBeOfType<InMemorySemaphoreProvider>();
+        provider.GetService<ISemaphoreService>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddInMemorySemaphore_WithConfigureOptions_ShouldSucceed()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddInMemorySemaphore(o =>
+        {
+            o.SemaphoreName = "test-sem";
+            o.MaxCount = 3;
+        });
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<ISemaphoreService>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddInMemorySemaphore_WithNullConfigureOptions_ShouldSucceed()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        // Null configureOptions means SemaphoreName stays at default;
+        // SemaphoreService validation is deferred until resolution.
+        // Only verify the provider itself is registered eagerly.
+        services.AddInMemorySemaphore(configureOptions: null);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ISemaphoreProvider? semaphoreProvider = provider.GetService<ISemaphoreProvider>();
+        semaphoreProvider.ShouldNotBeNull();
+        semaphoreProvider.ShouldBeOfType<InMemorySemaphoreProvider>();
+    }
 }
 

--- a/tests/MultiLock.Tests/ProviderGuardTests.cs
+++ b/tests/MultiLock.Tests/ProviderGuardTests.cs
@@ -1,0 +1,198 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MultiLock.AzureBlobStorage;
+using MultiLock.Consul;
+using MultiLock.PostgreSQL;
+using MultiLock.Redis;
+using MultiLock.SqlServer;
+using MultiLock.ZooKeeper;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+/// <summary>
+/// Shared guard-clause tests for every <see cref="ISemaphoreProvider"/> implementation. These cover
+/// argument validation, disposal behaviour, and the health-check disposed-state path - all of which
+/// run before any network access, so no live backend is required.
+/// </summary>
+public abstract class SemaphoreProviderGuardTestsBase
+{
+    private const string Sem = "sem1";
+    private const string Holder = "holder-1";
+    private const string BadName = "bad name!";
+    private static readonly IReadOnlyDictionary<string, string> Meta = new Dictionary<string, string>();
+    private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(1);
+
+    /// <summary>Creates a provider configured with a valid but non-connecting backend.</summary>
+    protected abstract ISemaphoreProvider CreateProvider();
+
+    [Fact]
+    public async Task TryAcquireAsync_WithInvalidSemaphoreName_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => provider.TryAcquireAsync(BadName, Holder, 1, Meta, Timeout));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithInvalidHolderId_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => provider.TryAcquireAsync(Sem, "  ", 1, Meta, Timeout));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithInvalidMaxCount_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => provider.TryAcquireAsync(Sem, Holder, 0, Meta, Timeout));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithNullMetadata_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => provider.TryAcquireAsync(Sem, Holder, 1, null!, Timeout));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WithInvalidSlotTimeout_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => provider.TryAcquireAsync(Sem, Holder, 1, Meta, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_WithInvalidSemaphoreName_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => provider.ReleaseAsync(BadName, Holder));
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WithInvalidSemaphoreName_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => provider.UpdateHeartbeatAsync(BadName, Holder, Meta));
+    }
+
+    [Fact]
+    public async Task UpdateHeartbeatAsync_WithNullMetadata_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => provider.UpdateHeartbeatAsync(Sem, Holder, null!));
+    }
+
+    [Fact]
+    public async Task GetCurrentCountAsync_WithInvalidSemaphoreName_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => provider.GetCurrentCountAsync(BadName, Timeout));
+    }
+
+    [Fact]
+    public async Task GetHoldersAsync_WithInvalidSemaphoreName_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => provider.GetHoldersAsync(BadName));
+    }
+
+    [Fact]
+    public async Task IsHoldingAsync_WithInvalidHolderId_Throws()
+    {
+        using ISemaphoreProvider provider = CreateProvider();
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => provider.IsHoldingAsync(Sem, ""));
+    }
+
+    [Fact]
+    public async Task HealthCheckAsync_AfterDispose_ReturnsFalse()
+    {
+        ISemaphoreProvider provider = CreateProvider();
+        provider.Dispose();
+        (await provider.HealthCheckAsync()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        ISemaphoreProvider provider = CreateProvider();
+        Should.NotThrow(() =>
+        {
+            provider.Dispose();
+            provider.Dispose();
+        });
+    }
+
+    [Fact]
+    public async Task Methods_AfterDispose_ThrowObjectDisposedException()
+    {
+        ISemaphoreProvider provider = CreateProvider();
+        provider.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => provider.TryAcquireAsync(Sem, Holder, 1, Meta, Timeout));
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => provider.ReleaseAsync(Sem, Holder));
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => provider.UpdateHeartbeatAsync(Sem, Holder, Meta));
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => provider.GetCurrentCountAsync(Sem, Timeout));
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => provider.GetHoldersAsync(Sem));
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => provider.IsHoldingAsync(Sem, Holder));
+    }
+}
+
+public class RedisSemaphoreProviderGuardTests : SemaphoreProviderGuardTestsBase
+{
+    protected override ISemaphoreProvider CreateProvider() =>
+        new RedisSemaphoreProvider(
+            Options.Create(new RedisSemaphoreOptions()),
+            NullLogger<RedisSemaphoreProvider>.Instance);
+}
+
+public class AzureBlobStorageSemaphoreProviderGuardTests : SemaphoreProviderGuardTestsBase
+{
+    protected override ISemaphoreProvider CreateProvider() =>
+        new AzureBlobStorageSemaphoreProvider(
+            Options.Create(new AzureBlobStorageSemaphoreOptions { ConnectionString = "UseDevelopmentStorage=true" }),
+            NullLogger<AzureBlobStorageSemaphoreProvider>.Instance);
+}
+
+public class ConsulSemaphoreProviderGuardTests : SemaphoreProviderGuardTestsBase
+{
+    protected override ISemaphoreProvider CreateProvider() =>
+        new ConsulSemaphoreProvider(
+            Options.Create(new ConsulSemaphoreOptions()),
+            NullLogger<ConsulSemaphoreProvider>.Instance);
+}
+
+public class PostgreSqlSemaphoreProviderGuardTests : SemaphoreProviderGuardTestsBase
+{
+    protected override ISemaphoreProvider CreateProvider() =>
+        new PostgreSqlSemaphoreProvider(
+            Options.Create(new PostgreSqlSemaphoreOptions { ConnectionString = "Host=localhost;Database=db;Username=u;Password=p" }),
+            NullLogger<PostgreSqlSemaphoreProvider>.Instance);
+}
+
+public class SqlServerSemaphoreProviderGuardTests : SemaphoreProviderGuardTestsBase
+{
+    protected override ISemaphoreProvider CreateProvider() =>
+        new SqlServerSemaphoreProvider(
+            Options.Create(new SqlServerSemaphoreOptions { ConnectionString = "Server=localhost;Database=db;Trusted_Connection=True" }),
+            NullLogger<SqlServerSemaphoreProvider>.Instance);
+}
+
+public class ZooKeeperSemaphoreProviderGuardTests : SemaphoreProviderGuardTestsBase
+{
+    protected override ISemaphoreProvider CreateProvider() =>
+        new ZooKeeperSemaphoreProvider(
+            Options.Create(new ZooKeeperSemaphoreOptions()),
+            NullLogger<ZooKeeperSemaphoreProvider>.Instance);
+}

--- a/tests/MultiLock.Tests/ProviderOptionsValidationTests.cs
+++ b/tests/MultiLock.Tests/ProviderOptionsValidationTests.cs
@@ -1,0 +1,188 @@
+using MultiLock.AzureBlobStorage;
+using MultiLock.Consul;
+using MultiLock.PostgreSQL;
+using MultiLock.Redis;
+using MultiLock.SqlServer;
+using MultiLock.ZooKeeper;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+/// <summary>
+/// Validation tests for every provider's options type. These exercise the option <c>Validate()</c>
+/// branches without requiring a live backend.
+/// </summary>
+public class ProviderOptionsValidationTests
+{
+    // ---- Redis ----
+
+    [Fact]
+    public void RedisOptions_Default_IsValid() =>
+        Should.NotThrow(() => new RedisSemaphoreOptions().Validate());
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RedisOptions_EmptyConnectionString_Throws(string connectionString) =>
+        Should.Throw<ArgumentException>(() => new RedisSemaphoreOptions { ConnectionString = connectionString }.Validate());
+
+    [Fact]
+    public void RedisOptions_EmptyKeyPrefix_Throws() =>
+        Should.Throw<ArgumentException>(() => new RedisSemaphoreOptions { KeyPrefix = "" }.Validate());
+
+    [Fact]
+    public void RedisOptions_NegativeDatabase_Throws() =>
+        Should.Throw<ArgumentException>(() => new RedisSemaphoreOptions { Database = -1 }.Validate());
+
+    // ---- Azure Blob Storage ----
+
+    [Fact]
+    public void AzureOptions_Valid_DoesNotThrow() =>
+        Should.NotThrow(() => new AzureBlobStorageSemaphoreOptions { ConnectionString = "UseDevelopmentStorage=true" }.Validate());
+
+    [Fact]
+    public void AzureOptions_EmptyConnectionString_Throws() =>
+        Should.Throw<ArgumentException>(() => new AzureBlobStorageSemaphoreOptions().Validate());
+
+    [Fact]
+    public void AzureOptions_EmptyContainerName_Throws() =>
+        Should.Throw<ArgumentException>(() => new AzureBlobStorageSemaphoreOptions
+        {
+            ConnectionString = "UseDevelopmentStorage=true",
+            ContainerName = ""
+        }.Validate());
+
+    [Fact]
+    public void AzureOptions_ZeroMaxRetryAttempts_Throws() =>
+        Should.Throw<ArgumentException>(() => new AzureBlobStorageSemaphoreOptions
+        {
+            ConnectionString = "UseDevelopmentStorage=true",
+            MaxRetryAttempts = 0
+        }.Validate());
+
+    // ---- Consul ----
+
+    [Fact]
+    public void ConsulOptions_Default_IsValid() =>
+        Should.NotThrow(() => new ConsulSemaphoreOptions().Validate());
+
+    [Fact]
+    public void ConsulOptions_EmptyAddress_Throws() =>
+        Should.Throw<ArgumentException>(() => new ConsulSemaphoreOptions { Address = "" }.Validate());
+
+    [Fact]
+    public void ConsulOptions_EmptyKeyPrefix_Throws() =>
+        Should.Throw<ArgumentException>(() => new ConsulSemaphoreOptions { KeyPrefix = "" }.Validate());
+
+    [Theory]
+    [InlineData(5)]      // below 10s minimum
+    [InlineData(90000)]  // above 24h maximum
+    public void ConsulOptions_SessionTtlOutOfRange_Throws(int seconds) =>
+        Should.Throw<ArgumentException>(() => new ConsulSemaphoreOptions { SessionTtl = TimeSpan.FromSeconds(seconds) }.Validate());
+
+    [Theory]
+    [InlineData(-1)]   // negative
+    [InlineData(120)]  // above 60s maximum
+    public void ConsulOptions_SessionLockDelayOutOfRange_Throws(int seconds) =>
+        Should.Throw<ArgumentException>(() => new ConsulSemaphoreOptions { SessionLockDelay = TimeSpan.FromSeconds(seconds) }.Validate());
+
+    // ---- PostgreSQL ----
+
+    [Fact]
+    public void PostgreSqlOptions_Valid_DoesNotThrow() =>
+        Should.NotThrow(() => new PostgreSqlSemaphoreOptions { ConnectionString = "Host=localhost;Database=db;Username=u;Password=p" }.Validate());
+
+    [Fact]
+    public void PostgreSqlOptions_EmptyConnectionString_Throws() =>
+        Should.Throw<ArgumentException>(() => new PostgreSqlSemaphoreOptions().Validate());
+
+    [Fact]
+    public void PostgreSqlOptions_EmptyTableName_Throws() =>
+        Should.Throw<ArgumentException>(() => new PostgreSqlSemaphoreOptions
+        {
+            ConnectionString = "Host=localhost",
+            TableName = ""
+        }.Validate());
+
+    [Theory]
+    [InlineData("bad-table")]      // hyphen not allowed in a SQL identifier
+    [InlineData("1table")]         // cannot start with a digit
+    [InlineData("table;drop")]     // injection attempt
+    public void PostgreSqlOptions_InvalidIdentifier_Throws(string tableName) =>
+        Should.Throw<ArgumentException>(() => new PostgreSqlSemaphoreOptions
+        {
+            ConnectionString = "Host=localhost",
+            TableName = tableName
+        }.Validate());
+
+    [Fact]
+    public void PostgreSqlOptions_NonPositiveCommandTimeout_Throws() =>
+        Should.Throw<ArgumentException>(() => new PostgreSqlSemaphoreOptions
+        {
+            ConnectionString = "Host=localhost",
+            CommandTimeoutSeconds = 0
+        }.Validate());
+
+    // ---- SQL Server ----
+
+    [Fact]
+    public void SqlServerOptions_Valid_DoesNotThrow() =>
+        Should.NotThrow(() => new SqlServerSemaphoreOptions { ConnectionString = "Server=localhost;Database=db;Trusted_Connection=True" }.Validate());
+
+    [Fact]
+    public void SqlServerOptions_EmptyConnectionString_Throws() =>
+        Should.Throw<ArgumentException>(() => new SqlServerSemaphoreOptions().Validate());
+
+    [Fact]
+    public void SqlServerOptions_EmptySchemaName_Throws() =>
+        Should.Throw<ArgumentException>(() => new SqlServerSemaphoreOptions
+        {
+            ConnectionString = "Server=localhost",
+            SchemaName = ""
+        }.Validate());
+
+    [Theory]
+    [InlineData("dbo;drop")]
+    [InlineData("9schema")]
+    public void SqlServerOptions_InvalidIdentifier_Throws(string schemaName) =>
+        Should.Throw<ArgumentException>(() => new SqlServerSemaphoreOptions
+        {
+            ConnectionString = "Server=localhost",
+            SchemaName = schemaName
+        }.Validate());
+
+    [Fact]
+    public void SqlServerOptions_NegativeCommandTimeout_Throws() =>
+        Should.Throw<ArgumentException>(() => new SqlServerSemaphoreOptions
+        {
+            ConnectionString = "Server=localhost",
+            CommandTimeoutSeconds = -5
+        }.Validate());
+
+    // ---- ZooKeeper ----
+
+    [Fact]
+    public void ZooKeeperOptions_Default_IsValid() =>
+        Should.NotThrow(() => new ZooKeeperSemaphoreOptions().Validate());
+
+    [Fact]
+    public void ZooKeeperOptions_EmptyConnectionString_Throws() =>
+        Should.Throw<ArgumentException>(() => new ZooKeeperSemaphoreOptions { ConnectionString = "" }.Validate());
+
+    [Fact]
+    public void ZooKeeperOptions_RootPathWithoutLeadingSlash_Throws() =>
+        Should.Throw<ArgumentException>(() => new ZooKeeperSemaphoreOptions { RootPath = "semaphores" }.Validate());
+
+    [Theory]
+    [InlineData(0)]      // non-positive
+    [InlineData(4000)]   // above 60 minute maximum
+    public void ZooKeeperOptions_SessionTimeoutOutOfRange_Throws(int seconds) =>
+        Should.Throw<ArgumentException>(() => new ZooKeeperSemaphoreOptions { SessionTimeout = TimeSpan.FromSeconds(seconds) }.Validate());
+
+    [Theory]
+    [InlineData(0)]      // non-positive
+    [InlineData(1200)]   // above 10 minute maximum
+    public void ZooKeeperOptions_ConnectionTimeoutOutOfRange_Throws(int seconds) =>
+        Should.Throw<ArgumentException>(() => new ZooKeeperSemaphoreOptions { ConnectionTimeout = TimeSpan.FromSeconds(seconds) }.Validate());
+}

--- a/tests/MultiLock.Tests/ProviderOptionsValidationTests.cs
+++ b/tests/MultiLock.Tests/ProviderOptionsValidationTests.cs
@@ -35,6 +35,19 @@ public class ProviderOptionsValidationTests
     public void RedisOptions_NegativeDatabase_Throws() =>
         Should.Throw<ArgumentException>(() => new RedisSemaphoreOptions { Database = -1 }.Validate());
 
+    [Theory]
+    [InlineData("bad prefix")]      // space not allowed
+    [InlineData("bad!")]            // punctuation not allowed
+    [InlineData("a/b")]             // slash not allowed
+    public void RedisOptions_InvalidKeyPrefix_Throws(string keyPrefix) =>
+        Should.Throw<ArgumentException>(() => new RedisSemaphoreOptions { KeyPrefix = keyPrefix }.Validate());
+
+    [Theory]
+    [InlineData("semaphore")]
+    [InlineData("ml:locks-1_test")]
+    public void RedisOptions_ValidKeyPrefix_DoesNotThrow(string keyPrefix) =>
+        Should.NotThrow(() => new RedisSemaphoreOptions { KeyPrefix = keyPrefix }.Validate());
+
     // ---- Azure Blob Storage ----
 
     [Fact]
@@ -59,6 +72,21 @@ public class ProviderOptionsValidationTests
         {
             ConnectionString = "UseDevelopmentStorage=true",
             MaxRetryAttempts = 0
+        }.Validate());
+
+    [Theory]
+    [InlineData("ab")]                // too short (< 3)
+    [InlineData("HasUpperCase")]      // uppercase not allowed
+    [InlineData("has_underscore")]    // underscore not allowed
+    [InlineData("-leading-hyphen")]   // must start with letter/digit
+    [InlineData("trailing-hyphen-")]  // must end with letter/digit
+    [InlineData("double--hyphen")]    // no consecutive hyphens
+    [InlineData("this-name-is-way-too-long-to-be-a-valid-azure-container-name-1234")] // > 63
+    public void AzureOptions_InvalidContainerName_Throws(string containerName) =>
+        Should.Throw<ArgumentException>(() => new AzureBlobStorageSemaphoreOptions
+        {
+            ConnectionString = "UseDevelopmentStorage=true",
+            ContainerName = containerName
         }.Validate());
 
     // ---- Consul ----
@@ -124,6 +152,22 @@ public class ProviderOptionsValidationTests
             CommandTimeoutSeconds = 0
         }.Validate());
 
+    [Fact]
+    public void PostgreSqlOptions_TableNameExceeding63Chars_Throws() =>
+        Should.Throw<ArgumentException>(() => new PostgreSqlSemaphoreOptions
+        {
+            ConnectionString = "Host=localhost",
+            TableName = new string('a', 64)
+        }.Validate());
+
+    [Fact]
+    public void PostgreSqlOptions_TableNameAt63Chars_DoesNotThrow() =>
+        Should.NotThrow(() => new PostgreSqlSemaphoreOptions
+        {
+            ConnectionString = "Host=localhost",
+            TableName = new string('a', 63)
+        }.Validate());
+
     // ---- SQL Server ----
 
     [Fact]
@@ -158,6 +202,23 @@ public class ProviderOptionsValidationTests
         {
             ConnectionString = "Server=localhost",
             CommandTimeoutSeconds = -5
+        }.Validate());
+
+    [Fact]
+    public void SqlServerOptions_TableNameAt100Chars_DoesNotThrow() =>
+        // SQL Server permits identifiers up to 128 chars, so the PostgreSQL 63-char limit must not apply here.
+        Should.NotThrow(() => new SqlServerSemaphoreOptions
+        {
+            ConnectionString = "Server=localhost",
+            TableName = new string('a', 100)
+        }.Validate());
+
+    [Fact]
+    public void SqlServerOptions_TableNameExceeding128Chars_Throws() =>
+        Should.Throw<ArgumentException>(() => new SqlServerSemaphoreOptions
+        {
+            ConnectionString = "Server=localhost",
+            TableName = new string('a', 129)
         }.Validate());
 
     // ---- ZooKeeper ----

--- a/tests/MultiLock.Tests/SemaphoreAcquisitionTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreAcquisitionTests.cs
@@ -1,0 +1,148 @@
+using Microsoft.Extensions.Logging;
+using MultiLock.InMemory;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+public class SemaphoreAcquisitionTests : IDisposable
+{
+    private readonly InMemorySemaphoreProvider provider;
+    private readonly ILoggerFactory loggerFactory;
+    private const string SemaphoreName = "acq-test";
+    private const string HolderId = "holder-1";
+    private readonly IReadOnlyDictionary<string, string> metadata = new Dictionary<string, string>();
+
+    public SemaphoreAcquisitionTests()
+    {
+        loggerFactory = new LoggerFactory();
+        provider = new InMemorySemaphoreProvider(loggerFactory.CreateLogger<InMemorySemaphoreProvider>());
+    }
+
+    public void Dispose()
+    {
+        provider.Dispose();
+        loggerFactory.Dispose();
+    }
+
+    private SemaphoreAcquisition CreateAcquisition() =>
+        new(provider, SemaphoreName, HolderId, DateTimeOffset.UtcNow, metadata);
+
+    [Fact]
+    public void IsDisposed_BeforeDispose_ShouldReturnFalse()
+    {
+        var acquisition = CreateAcquisition();
+        acquisition.IsDisposed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldSetIsDisposedTrue()
+    {
+        var acquisition = CreateAcquisition();
+        await acquisition.DisposeAsync();
+        acquisition.IsDisposed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Dispose_ShouldSetIsDisposedTrue()
+    {
+        var acquisition = CreateAcquisition();
+        acquisition.Dispose();
+        acquisition.IsDisposed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldReleaseSlotFromProvider()
+    {
+        // Acquire a slot first so the provider knows about this holder
+        await provider.TryAcquireAsync(SemaphoreName, HolderId, 3, metadata, TimeSpan.FromMinutes(5));
+        bool holdingBefore = await provider.IsHoldingAsync(SemaphoreName, HolderId);
+        holdingBefore.ShouldBeTrue();
+
+        var acquisition = CreateAcquisition();
+        await acquisition.DisposeAsync();
+
+        bool holdingAfter = await provider.IsHoldingAsync(SemaphoreName, HolderId);
+        holdingAfter.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Dispose_ShouldReleaseSlotFromProvider()
+    {
+        await provider.TryAcquireAsync(SemaphoreName, HolderId, 3, metadata, TimeSpan.FromMinutes(5));
+
+        var acquisition = CreateAcquisition();
+        acquisition.Dispose();
+
+        bool holding = await provider.IsHoldingAsync(SemaphoreName, HolderId);
+        holding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CalledTwice_ShouldNotDoubleRelease()
+    {
+        // Acquire slot for holder-1, then dispose twice; verify second dispose doesn't throw
+        // and count stays correct
+        const string otherHolder = "holder-2";
+        const int maxCount = 1;
+        await provider.TryAcquireAsync(SemaphoreName, HolderId, maxCount, metadata, TimeSpan.FromMinutes(5));
+
+        var acquisition = CreateAcquisition();
+        await acquisition.DisposeAsync(); // releases holder-1
+        await acquisition.DisposeAsync(); // second call is a no-op
+
+        // holder-2 should be able to acquire since the slot is free
+        bool acquired = await provider.TryAcquireAsync(SemaphoreName, otherHolder, maxCount, metadata, TimeSpan.FromMinutes(5));
+        acquired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ConcurrentCalls_ShouldNotDoubleRelease()
+    {
+        // Arrange: acquire a slot then fire many concurrent DisposeAsync calls.
+        // The volatile-bool guard has a read-then-write pattern that is not atomically
+        // compare-and-swap, so multiple callers may race past the isDisposed check.
+        // The test verifies that even in the worst case the semaphore ends up in a
+        // consistent state: the slot is released exactly once, the acquisition is
+        // marked disposed, and no exception escapes.
+        const string otherHolder = "holder-2";
+        const int maxCount = 1;
+        const int concurrency = 8;
+
+        await provider.TryAcquireAsync(SemaphoreName, HolderId, maxCount, metadata, TimeSpan.FromMinutes(5));
+        var acquisition = CreateAcquisition();
+
+        // Act: Task.WhenAll rethrows the first faulted task; any unexpected exception
+        // here is a test failure (DisposeAsync is specified never to throw).
+        Task[] disposeTasks = Enumerable
+            .Range(0, concurrency)
+            .Select(_ => acquisition.DisposeAsync().AsTask())
+            .ToArray();
+        await Task.WhenAll(disposeTasks);
+
+        // Assert: the acquisition must be marked disposed regardless of which task won.
+        acquisition.IsDisposed.ShouldBeTrue();
+
+        // The slot must be free: no phantom holders left from double-release races.
+        int count = await provider.GetCurrentCountAsync(SemaphoreName, TimeSpan.FromMinutes(5));
+        count.ShouldBe(0, "holder-1 slot should be fully released after concurrent disposal");
+
+        // A new holder should be able to acquire the now-free slot.
+        bool acquired = await provider.TryAcquireAsync(
+            SemaphoreName, otherHolder, maxCount, metadata, TimeSpan.FromMinutes(5));
+        acquired.ShouldBeTrue("slot should be available for a new holder after concurrent disposal");
+    }
+
+    [Fact]
+    public void Properties_ShouldBeSetCorrectly()
+    {
+        var acquiredAt = DateTimeOffset.UtcNow;
+        var meta = new Dictionary<string, string> { { "k", "v" } };
+        var acquisition = new SemaphoreAcquisition(provider, SemaphoreName, HolderId, acquiredAt, meta);
+
+        acquisition.HolderId.ShouldBe(HolderId);
+        acquisition.AcquiredAt.ShouldBe(acquiredAt);
+        acquisition.Metadata["k"].ShouldBe("v");
+    }
+}
+

--- a/tests/MultiLock.Tests/SemaphoreAcquisitionTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreAcquisitionTests.cs
@@ -109,7 +109,8 @@ public class SemaphoreAcquisitionTests : IDisposable
         const int maxCount = 1;
         const int concurrency = 8;
 
-        await provider.TryAcquireAsync(SemaphoreName, HolderId, maxCount, metadata, TimeSpan.FromMinutes(5));
+        (await provider.TryAcquireAsync(SemaphoreName, HolderId, maxCount, metadata, TimeSpan.FromMinutes(5)))
+            .ShouldBeTrue("setup: holder-1 should acquire the only slot");
         var acquisition = CreateAcquisition();
 
         // Act: Task.WhenAll rethrows the first faulted task; any unexpected exception

--- a/tests/MultiLock.Tests/SemaphoreConcurrencyTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreConcurrencyTests.cs
@@ -1,0 +1,172 @@
+﻿using Microsoft.Extensions.Logging;
+using MultiLock.InMemory;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+public class SemaphoreConcurrencyTests : IDisposable
+{
+    private readonly InMemorySemaphoreProvider provider;
+    private readonly ILoggerFactory loggerFactory;
+
+    public SemaphoreConcurrencyTests()
+    {
+        loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        provider = new InMemorySemaphoreProvider(loggerFactory.CreateLogger<InMemorySemaphoreProvider>());
+    }
+
+    public void Dispose()
+    {
+        provider.Dispose();
+        loggerFactory.Dispose();
+    }
+
+    [Fact]
+    public async Task ConcurrentAcquire_ShouldRespectMaxCount()
+    {
+        // Arrange
+        const string semaphoreName = "concurrent-test";
+        const int maxCount = 5;
+        const int totalHolders = 20;
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        // Act - try to acquire from many holders concurrently
+        var tasks = Enumerable.Range(0, totalHolders)
+            .Select(i => provider.TryAcquireAsync(semaphoreName, $"holder-{i}", maxCount, metadata, slotTimeout))
+            .ToList();
+
+        bool[] results = await Task.WhenAll(tasks);
+
+        // Assert - exactly maxCount should succeed
+        int successCount = results.Count(r => r);
+        successCount.ShouldBe(maxCount);
+    }
+
+    [Fact]
+    public async Task ConcurrentAcquireAndRelease_ShouldMaintainConsistency()
+    {
+        // Arrange
+        const string semaphoreName = "acquire-release-test";
+        const int maxCount = 3;
+        const int iterations = 50;
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        // Act - acquire and release in parallel
+        var tasks = Enumerable.Range(0, iterations).Select(async i =>
+        {
+            string holderId = $"holder-{i}";
+            bool acquired = await provider.TryAcquireAsync(semaphoreName, holderId, maxCount, metadata, slotTimeout);
+            if (acquired)
+            {
+                await Task.Delay(Random.Shared.Next(1, 10)); // Simulate work
+                await provider.ReleaseAsync(semaphoreName, holderId);
+            }
+            return acquired;
+        }).ToList();
+
+        await Task.WhenAll(tasks);
+
+        // Assert - semaphore should be empty after all releases
+        int finalCount = await provider.GetCurrentCountAsync(semaphoreName, slotTimeout);
+        finalCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ConcurrentGetCurrentCount_ShouldBeThreadSafe()
+    {
+        // Arrange
+        const string semaphoreName = "count-test";
+        const int maxCount = 10;
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        // Acquire some slots
+        for (int i = 0; i < 5; i++)
+            await provider.TryAcquireAsync(semaphoreName, $"holder-{i}", maxCount, metadata, slotTimeout);
+
+        // Act - read count from many threads concurrently
+        var tasks = Enumerable.Range(0, 100)
+            .Select(_ => provider.GetCurrentCountAsync(semaphoreName, slotTimeout))
+            .ToList();
+
+        int[] counts = await Task.WhenAll(tasks);
+
+        // Assert - all reads should return the same value
+        counts.ShouldAllBe(c => c == 5);
+    }
+
+    [Fact]
+    public async Task ConcurrentIsHolding_ShouldBeThreadSafe()
+    {
+        // Arrange
+        const string semaphoreName = "holding-test";
+        const int maxCount = 10;
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        await provider.TryAcquireAsync(semaphoreName, "holder-1", maxCount, metadata, slotTimeout);
+
+        // Act - check holding status from many threads concurrently
+        var tasks = Enumerable.Range(0, 100)
+            .Select(_ => provider.IsHoldingAsync(semaphoreName, "holder-1"))
+            .ToList();
+
+        bool[] results = await Task.WhenAll(tasks);
+
+        // Assert - all reads should return true
+        results.ShouldAllBe(r => r);
+    }
+
+    [Fact]
+    public async Task ConcurrentGetHolders_ShouldBeThreadSafe()
+    {
+        // Arrange
+        const string semaphoreName = "holders-test";
+        const int maxCount = 10;
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        for (int i = 0; i < 5; i++)
+            await provider.TryAcquireAsync(semaphoreName, $"holder-{i}", maxCount, metadata, slotTimeout);
+
+        // Act - get holders from many threads concurrently
+        var tasks = Enumerable.Range(0, 100)
+            .Select(_ => provider.GetHoldersAsync(semaphoreName))
+            .ToList();
+
+        var results = await Task.WhenAll(tasks);
+
+        // Assert - all reads should return 5 holders
+        results.ShouldAllBe(r => r.Count == 5);
+    }
+
+    [Fact]
+    public async Task RapidAcquireReleaseCycles_ShouldNotDeadlock()
+    {
+        // Arrange
+        const string semaphoreName = "rapid-cycle-test";
+        const int maxCount = 2;
+        const int cycles = 100;
+        var metadata = new Dictionary<string, string>();
+        var slotTimeout = TimeSpan.FromMinutes(5);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        // Act - rapid acquire/release cycles from multiple holders
+        var tasks = Enumerable.Range(0, 4).Select(async holderIndex =>
+        {
+            string holderId = $"holder-{holderIndex}";
+            for (int i = 0; i < cycles && !cts.Token.IsCancellationRequested; i++)
+            {
+                await provider.TryAcquireAsync(semaphoreName, holderId, maxCount, metadata, slotTimeout, cts.Token);
+                await provider.ReleaseAsync(semaphoreName, holderId, cts.Token);
+            }
+        }).ToList();
+
+        // Assert - should complete without deadlock
+        await Task.WhenAll(tasks);
+    }
+}
+

--- a/tests/MultiLock.Tests/SemaphoreConcurrencyTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreConcurrencyTests.cs
@@ -32,9 +32,11 @@ public class SemaphoreConcurrencyTests : IDisposable
         var metadata = new Dictionary<string, string>();
         var slotTimeout = TimeSpan.FromMinutes(5);
 
-        // Act - try to acquire from many holders concurrently
+        // Act - try to acquire from many holders concurrently. The provider methods complete
+        // synchronously under a lock, so wrap each call in Task.Run to dispatch it onto the thread
+        // pool and create genuine concurrent contention rather than serial execution.
         var tasks = Enumerable.Range(0, totalHolders)
-            .Select(i => provider.TryAcquireAsync(semaphoreName, $"holder-{i}", maxCount, metadata, slotTimeout))
+            .Select(i => Task.Run(() => provider.TryAcquireAsync(semaphoreName, $"holder-{i}", maxCount, metadata, slotTimeout)))
             .ToList();
 
         bool[] results = await Task.WhenAll(tasks);
@@ -89,7 +91,7 @@ public class SemaphoreConcurrencyTests : IDisposable
 
         // Act - read count from many threads concurrently
         var tasks = Enumerable.Range(0, 100)
-            .Select(_ => provider.GetCurrentCountAsync(semaphoreName, slotTimeout))
+            .Select(_ => Task.Run(() => provider.GetCurrentCountAsync(semaphoreName, slotTimeout)))
             .ToList();
 
         int[] counts = await Task.WhenAll(tasks);
@@ -111,7 +113,7 @@ public class SemaphoreConcurrencyTests : IDisposable
 
         // Act - check holding status from many threads concurrently
         var tasks = Enumerable.Range(0, 100)
-            .Select(_ => provider.IsHoldingAsync(semaphoreName, "holder-1"))
+            .Select(_ => Task.Run(() => provider.IsHoldingAsync(semaphoreName, "holder-1")))
             .ToList();
 
         bool[] results = await Task.WhenAll(tasks);
@@ -134,7 +136,7 @@ public class SemaphoreConcurrencyTests : IDisposable
 
         // Act - get holders from many threads concurrently
         var tasks = Enumerable.Range(0, 100)
-            .Select(_ => provider.GetHoldersAsync(semaphoreName))
+            .Select(_ => Task.Run(() => provider.GetHoldersAsync(semaphoreName)))
             .ToList();
 
         var results = await Task.WhenAll(tasks);
@@ -154,19 +156,32 @@ public class SemaphoreConcurrencyTests : IDisposable
         var slotTimeout = TimeSpan.FromMinutes(5);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        // Act - rapid acquire/release cycles from multiple holders
-        var tasks = Enumerable.Range(0, 4).Select(async holderIndex =>
+        // Act - rapid acquire/release cycles from multiple holders, each on its own thread.
+        var tasks = Enumerable.Range(0, 4).Select(holderIndex => Task.Run(async () =>
         {
             string holderId = $"holder-{holderIndex}";
+            int acquiredCount = 0;
             for (int i = 0; i < cycles && !cts.Token.IsCancellationRequested; i++)
             {
-                await provider.TryAcquireAsync(semaphoreName, holderId, maxCount, metadata, slotTimeout, cts.Token);
-                await provider.ReleaseAsync(semaphoreName, holderId, cts.Token);
+                // Only release when the acquire actually succeeded; releasing unconditionally would
+                // let the test pass even if every acquire failed.
+                bool acquired = await provider.TryAcquireAsync(semaphoreName, holderId, maxCount, metadata, slotTimeout, cts.Token);
+                if (acquired)
+                {
+                    acquiredCount++;
+                    await provider.ReleaseAsync(semaphoreName, holderId, cts.Token);
+                }
             }
-        }).ToList();
+            return acquiredCount;
+        })).ToList();
 
-        // Assert - should complete without deadlock
-        await Task.WhenAll(tasks);
+        // Assert - completes without deadlock and makes real forward progress.
+        int[] acquiredPerHolder = await Task.WhenAll(tasks);
+        acquiredPerHolder.Sum().ShouldBeGreaterThan(0, "holders should successfully acquire the semaphore across the cycles");
+
+        // The semaphore should be empty once every holder has released.
+        int finalCount = await provider.GetCurrentCountAsync(semaphoreName, slotTimeout);
+        finalCount.ShouldBe(0);
     }
 }
 

--- a/tests/MultiLock.Tests/SemaphoreExceptionTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreExceptionTests.cs
@@ -1,0 +1,143 @@
+using MultiLock.Exceptions;
+using Shouldly;
+using Xunit;
+
+// Disambiguate from System.Threading.SemaphoreFullException
+using SemaphoreFullException = MultiLock.Exceptions.SemaphoreFullException;
+
+namespace MultiLock.Tests;
+
+public class SemaphoreExceptionTests
+{
+    // SemaphoreException
+
+    [Fact]
+    public void SemaphoreException_DefaultCtor_ShouldCreateInstance()
+    {
+        var ex = new SemaphoreException();
+        ex.ShouldBeOfType<SemaphoreException>();
+        ex.ShouldBeAssignableTo<Exception>();
+    }
+
+    [Fact]
+    public void SemaphoreException_MessageCtor_ShouldSetMessage()
+    {
+        var ex = new SemaphoreException("test message");
+        ex.Message.ShouldBe("test message");
+    }
+
+    [Fact]
+    public void SemaphoreException_InnerExceptionCtor_ShouldSetInnerException()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new SemaphoreException("outer", inner);
+        ex.Message.ShouldBe("outer");
+        ex.InnerException.ShouldBe(inner);
+    }
+
+    // SemaphoreProviderException
+
+    [Fact]
+    public void SemaphoreProviderException_DefaultCtor_ShouldCreateInstance()
+    {
+        var ex = new SemaphoreProviderException();
+        ex.ShouldBeAssignableTo<SemaphoreException>();
+    }
+
+    [Fact]
+    public void SemaphoreProviderException_MessageCtor_ShouldSetMessage()
+    {
+        var ex = new SemaphoreProviderException("provider error");
+        ex.Message.ShouldBe("provider error");
+    }
+
+    [Fact]
+    public void SemaphoreProviderException_InnerExceptionCtor_ShouldSetInnerException()
+    {
+        var inner = new TimeoutException("timed out");
+        var ex = new SemaphoreProviderException("provider failed", inner);
+        ex.Message.ShouldBe("provider failed");
+        ex.InnerException.ShouldBe(inner);
+    }
+
+    // SemaphoreFullException
+
+    [Fact]
+    public void SemaphoreFullException_DefaultCtor_ShouldCreateInstance()
+    {
+        var ex = new SemaphoreFullException();
+        ex.ShouldBeAssignableTo<SemaphoreException>();
+        ex.SemaphoreName.ShouldBeNull();
+        ex.MaxCount.ShouldBeNull();
+        ex.CurrentCount.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SemaphoreFullException_MessageCtor_ShouldSetMessage()
+    {
+        var ex = new SemaphoreFullException("semaphore is full");
+        ex.Message.ShouldBe("semaphore is full");
+    }
+
+    [Fact]
+    public void SemaphoreFullException_InnerExceptionCtor_ShouldSetInnerException()
+    {
+        var inner = new Exception("cause");
+        var ex = new SemaphoreFullException("full", inner);
+        ex.InnerException.ShouldBe(inner);
+    }
+
+    [Fact]
+    public void SemaphoreFullException_Properties_ShouldBeSettable()
+    {
+        var ex = new SemaphoreFullException("full")
+        {
+            SemaphoreName = "my-semaphore",
+            MaxCount = 5,
+            CurrentCount = 5
+        };
+        ex.SemaphoreName.ShouldBe("my-semaphore");
+        ex.MaxCount.ShouldBe(5);
+        ex.CurrentCount.ShouldBe(5);
+    }
+
+    // SemaphoreTimeoutException
+
+    [Fact]
+    public void SemaphoreTimeoutException_DefaultCtor_ShouldCreateInstance()
+    {
+        var ex = new SemaphoreTimeoutException();
+        ex.ShouldBeAssignableTo<SemaphoreException>();
+        ex.Timeout.ShouldBeNull();
+        ex.SemaphoreName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SemaphoreTimeoutException_MessageCtor_ShouldSetMessage()
+    {
+        var ex = new SemaphoreTimeoutException("timed out waiting");
+        ex.Message.ShouldBe("timed out waiting");
+    }
+
+    [Fact]
+    public void SemaphoreTimeoutException_InnerExceptionCtor_ShouldSetInnerException()
+    {
+        var inner = new TimeoutException("underlying");
+        var ex = new SemaphoreTimeoutException("timeout", inner);
+        ex.InnerException.ShouldBe(inner);
+    }
+
+    [Fact]
+    public void SemaphoreTimeoutException_Properties_ShouldBeSettable()
+    {
+        var timeout = TimeSpan.FromSeconds(30);
+        var ex = new SemaphoreTimeoutException("timeout")
+        {
+            Timeout = timeout,
+            SemaphoreName = "rate-limiter"
+        };
+        ex.Timeout.ShouldBe(timeout);
+        ex.SemaphoreName.ShouldBe("rate-limiter");
+    }
+}
+

--- a/tests/MultiLock.Tests/SemaphoreModelTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreModelTests.cs
@@ -1,0 +1,165 @@
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+/// <summary>
+/// Tests for semaphore model types: SemaphoreStatus, SemaphoreInfo, SemaphoreHolder, SemaphoreChangedEventArgs.
+/// </summary>
+public class SemaphoreModelTests
+{
+    // SemaphoreStatus
+
+    [Fact]
+    public void SemaphoreStatus_Holding_ShouldSetIsHoldingTrue()
+    {
+        var status = SemaphoreStatus.Holding(currentCount: 2, maxCount: 5);
+        status.IsHolding.ShouldBeTrue();
+        status.CurrentCount.ShouldBe(2);
+        status.MaxCount.ShouldBe(5);
+        status.LastAcquisitionAttempt.ShouldNotBeNull();
+        status.NextAcquisitionAttempt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SemaphoreStatus_Waiting_ShouldSetIsHoldingFalse()
+    {
+        var next = DateTimeOffset.UtcNow.AddSeconds(5);
+        var status = SemaphoreStatus.Waiting(currentCount: 3, maxCount: 3, nextAttempt: next);
+        status.IsHolding.ShouldBeFalse();
+        status.CurrentCount.ShouldBe(3);
+        status.MaxCount.ShouldBe(3);
+        status.NextAcquisitionAttempt.ShouldBe(next);
+    }
+
+    [Fact]
+    public void SemaphoreStatus_Unknown_ShouldHaveZeroCount()
+    {
+        var status = SemaphoreStatus.Unknown(maxCount: 10);
+        status.IsHolding.ShouldBeFalse();
+        status.CurrentCount.ShouldBe(0);
+        status.MaxCount.ShouldBe(10);
+        status.LastAcquisitionAttempt.ShouldBeNull();
+        status.NextAcquisitionAttempt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SemaphoreStatus_AvailableSlots_ShouldReturnDifference()
+    {
+        var status = SemaphoreStatus.Holding(currentCount: 2, maxCount: 5);
+        status.AvailableSlots.ShouldBe(3);
+    }
+
+    [Fact]
+    public void SemaphoreStatus_AvailableSlots_WhenOverAdmitted_ShouldReturnZero()
+    {
+        // Simulate transient over-admission where currentCount exceeds maxCount
+        var status = new SemaphoreStatus(false, CurrentCount: 6, MaxCount: 5, null, null);
+        status.AvailableSlots.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SemaphoreStatus_HasAvailableSlots_WhenSlotsAvailable_ShouldReturnTrue()
+    {
+        var status = SemaphoreStatus.Holding(currentCount: 1, maxCount: 5);
+        status.HasAvailableSlots.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SemaphoreStatus_HasAvailableSlots_WhenFull_ShouldReturnFalse()
+    {
+        var status = SemaphoreStatus.Holding(currentCount: 5, maxCount: 5);
+        status.HasAvailableSlots.ShouldBeFalse();
+    }
+
+    // SemaphoreInfo
+
+    [Fact]
+    public void SemaphoreInfo_AvailableSlots_ShouldReturnDifference()
+    {
+        var info = new SemaphoreInfo("test", MaxCount: 5, CurrentCount: 2, Holders: []);
+        info.AvailableSlots.ShouldBe(3);
+    }
+
+    [Fact]
+    public void SemaphoreInfo_AvailableSlots_WhenOverAdmitted_ShouldReturnZero()
+    {
+        var info = new SemaphoreInfo("test", MaxCount: 3, CurrentCount: 5, Holders: []);
+        info.AvailableSlots.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SemaphoreInfo_HasAvailableSlots_WhenNotFull_ShouldReturnTrue()
+    {
+        var info = new SemaphoreInfo("test", MaxCount: 5, CurrentCount: 2, Holders: []);
+        info.HasAvailableSlots.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SemaphoreInfo_IsFull_WhenAtCapacity_ShouldReturnTrue()
+    {
+        var info = new SemaphoreInfo("test", MaxCount: 3, CurrentCount: 3, Holders: []);
+        info.IsFull.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SemaphoreInfo_IsFull_WhenBelowCapacity_ShouldReturnFalse()
+    {
+        var info = new SemaphoreInfo("test", MaxCount: 3, CurrentCount: 2, Holders: []);
+        info.IsFull.ShouldBeFalse();
+    }
+
+    // SemaphoreHolder
+
+    [Fact]
+    public void SemaphoreHolder_IsHealthy_WhenRecentHeartbeat_ShouldReturnTrue()
+    {
+        var holder = new SemaphoreHolder("h1", DateTimeOffset.UtcNow.AddMinutes(-1),
+            DateTimeOffset.UtcNow.AddSeconds(-5), new Dictionary<string, string>());
+        holder.IsHealthy(TimeSpan.FromSeconds(30)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SemaphoreHolder_IsHealthy_WhenStaleHeartbeat_ShouldReturnFalse()
+    {
+        var holder = new SemaphoreHolder("h1", DateTimeOffset.UtcNow.AddMinutes(-5),
+            DateTimeOffset.UtcNow.AddSeconds(-60), new Dictionary<string, string>());
+        holder.IsHealthy(TimeSpan.FromSeconds(30)).ShouldBeFalse();
+    }
+
+    // SemaphoreChangedEventArgs
+
+    [Fact]
+    public void SemaphoreChangedEventArgs_AcquiredSlot_WhenTransitioningToHolding_ShouldReturnTrue()
+    {
+        var prev = SemaphoreStatus.Waiting(0, 5, null);
+        var curr = SemaphoreStatus.Holding(1, 5);
+        var args = new SemaphoreChangedEventArgs(prev, curr);
+        args.AcquiredSlot.ShouldBeTrue();
+        args.LostSlot.ShouldBeFalse();
+        args.HoldingStatusChanged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SemaphoreChangedEventArgs_LostSlot_WhenTransitioningFromHolding_ShouldReturnTrue()
+    {
+        var prev = SemaphoreStatus.Holding(1, 5);
+        var curr = SemaphoreStatus.Waiting(0, 5, null);
+        var args = new SemaphoreChangedEventArgs(prev, curr);
+        args.LostSlot.ShouldBeTrue();
+        args.AcquiredSlot.ShouldBeFalse();
+        args.HoldingStatusChanged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SemaphoreChangedEventArgs_WhenStatusUnchanged_ShouldReturnFalse()
+    {
+        var prev = SemaphoreStatus.Waiting(1, 5, null);
+        var curr = SemaphoreStatus.Waiting(2, 5, null);
+        var args = new SemaphoreChangedEventArgs(prev, curr);
+        args.AcquiredSlot.ShouldBeFalse();
+        args.LostSlot.ShouldBeFalse();
+        args.HoldingStatusChanged.ShouldBeFalse();
+    }
+}
+

--- a/tests/MultiLock.Tests/SemaphoreModelTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreModelTests.cs
@@ -44,6 +44,24 @@ public class SemaphoreModelTests
     }
 
     [Fact]
+    public void SemaphoreStatus_Unknown_ShouldReportNoAvailableSlots()
+    {
+        // Before the first provider read the count is unobserved, so availability must be
+        // conservative (false) rather than implying the whole semaphore is free.
+        var status = SemaphoreStatus.Unknown(maxCount: 10);
+        status.HasInformation.ShouldBeFalse();
+        status.AvailableSlots.ShouldBe(0);
+        status.HasAvailableSlots.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SemaphoreStatus_HoldingAndWaiting_ShouldHaveInformation()
+    {
+        SemaphoreStatus.Holding(currentCount: 1, maxCount: 5).HasInformation.ShouldBeTrue();
+        SemaphoreStatus.Waiting(currentCount: 1, maxCount: 5, nextAttempt: null).HasInformation.ShouldBeTrue();
+    }
+
+    [Fact]
     public void SemaphoreStatus_AvailableSlots_ShouldReturnDifference()
     {
         var status = SemaphoreStatus.Holding(currentCount: 2, maxCount: 5);

--- a/tests/MultiLock.Tests/SemaphoreOptionsValidationTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreOptionsValidationTests.cs
@@ -1,0 +1,163 @@
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+public class SemaphoreOptionsValidationTests
+{
+    private static SemaphoreOptions ValidOptions() => new()
+    {
+        SemaphoreName = "test-semaphore",
+        MaxCount = 3,
+        HeartbeatInterval = TimeSpan.FromSeconds(5),
+        HeartbeatTimeout = TimeSpan.FromSeconds(30),
+        AcquisitionInterval = TimeSpan.FromSeconds(5),
+        MaxRetryAttempts = 3,
+        RetryBaseDelay = TimeSpan.FromMilliseconds(100),
+        RetryMaxDelay = TimeSpan.FromSeconds(5)
+    };
+
+    [Fact]
+    public void Validate_WithValidOptions_ShouldNotThrow()
+    {
+        Should.NotThrow(() => ValidOptions().Validate());
+    }
+
+    [Fact]
+    public void Validate_WithEmptySemaphoreName_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.SemaphoreName = "";
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("SemaphoreName");
+    }
+
+    [Fact]
+    public void Validate_WithWhitespaceSemaphoreName_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.SemaphoreName = "   ";
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("SemaphoreName");
+    }
+
+    [Fact]
+    public void Validate_WithMaxCountZero_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.MaxCount = 0;
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("MaxCount");
+    }
+
+    [Fact]
+    public void Validate_WithMaxCountNegative_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.MaxCount = -1;
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("MaxCount");
+    }
+
+    [Fact]
+    public void Validate_WithZeroHeartbeatInterval_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.HeartbeatInterval = TimeSpan.Zero;
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("HeartbeatInterval");
+    }
+
+    [Fact]
+    public void Validate_WithZeroHeartbeatTimeout_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.HeartbeatTimeout = TimeSpan.Zero;
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("HeartbeatTimeout");
+    }
+
+    [Fact]
+    public void Validate_WithHeartbeatTimeoutEqualToInterval_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.HeartbeatInterval = TimeSpan.FromSeconds(10);
+        options.HeartbeatTimeout = TimeSpan.FromSeconds(10);
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("HeartbeatTimeout");
+    }
+
+    [Fact]
+    public void Validate_WithHeartbeatTimeoutLessThanInterval_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.HeartbeatInterval = TimeSpan.FromSeconds(30);
+        options.HeartbeatTimeout = TimeSpan.FromSeconds(10);
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("HeartbeatTimeout");
+    }
+
+    [Fact]
+    public void Validate_WithZeroAcquisitionInterval_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.AcquisitionInterval = TimeSpan.Zero;
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("AcquisitionInterval");
+    }
+
+    [Fact]
+    public void Validate_WithNegativeMaxRetryAttempts_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.MaxRetryAttempts = -1;
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("MaxRetryAttempts");
+    }
+
+    [Fact]
+    public void Validate_WithZeroRetryBaseDelay_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.RetryBaseDelay = TimeSpan.Zero;
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("RetryBaseDelay");
+    }
+
+    [Fact]
+    public void Validate_WithZeroRetryMaxDelay_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.RetryMaxDelay = TimeSpan.Zero;
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("RetryMaxDelay");
+    }
+
+    [Fact]
+    public void Validate_WithRetryMaxDelayLessThanBase_ShouldThrow()
+    {
+        var options = ValidOptions();
+        options.RetryBaseDelay = TimeSpan.FromSeconds(5);
+        options.RetryMaxDelay = TimeSpan.FromSeconds(1);
+        Should.Throw<ArgumentException>(() => options.Validate())
+            .ParamName.ShouldBe("RetryMaxDelay");
+    }
+
+    [Fact]
+    public void Validate_WithMaxRetryAttemptsZero_ShouldNotThrow()
+    {
+        var options = ValidOptions();
+        options.MaxRetryAttempts = 0;
+        Should.NotThrow(() => options.Validate());
+    }
+
+    [Fact]
+    public void Validate_WithRetryBaseDelayEqualsMaxDelay_ShouldNotThrow()
+    {
+        var options = ValidOptions();
+        options.RetryBaseDelay = TimeSpan.FromSeconds(1);
+        options.RetryMaxDelay = TimeSpan.FromSeconds(1);
+        Should.NotThrow(() => options.Validate());
+    }
+}
+

--- a/tests/MultiLock.Tests/SemaphoreParameterValidationTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreParameterValidationTests.cs
@@ -1,0 +1,294 @@
+﻿using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+/// <summary>
+/// Tests for semaphore-related parameter validation methods.
+/// </summary>
+public class SemaphoreParameterValidationTests
+{
+    // ValidateSemaphoreName tests
+
+    [Fact]
+    public void ValidateSemaphoreName_WithValidValue_ShouldNotThrow()
+    {
+        // Arrange
+        const string validSemaphoreName = "valid-semaphore_name.123";
+
+        // Act & Assert
+        Should.NotThrow(() => ParameterValidation.ValidateSemaphoreName(validSemaphoreName));
+    }
+
+    [Fact]
+    public void ValidateSemaphoreName_WithNull_ShouldThrowArgumentException()
+    {
+        // Arrange
+        string? semaphoreName = null;
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateSemaphoreName(semaphoreName!));
+        exception.ParamName.ShouldBe("semaphoreName");
+        exception.Message.ShouldContain("cannot be null, empty, or whitespace");
+    }
+
+    [Fact]
+    public void ValidateSemaphoreName_WithEmptyString_ShouldThrowArgumentException()
+    {
+        // Arrange
+        const string semaphoreName = "";
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateSemaphoreName(semaphoreName));
+        exception.ParamName.ShouldBe("semaphoreName");
+        exception.Message.ShouldContain("cannot be null, empty, or whitespace");
+    }
+
+    [Fact]
+    public void ValidateSemaphoreName_WithWhitespace_ShouldThrowArgumentException()
+    {
+        // Arrange
+        const string semaphoreName = "   ";
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateSemaphoreName(semaphoreName));
+        exception.ParamName.ShouldBe("semaphoreName");
+        exception.Message.ShouldContain("cannot be null, empty, or whitespace");
+    }
+
+    [Fact]
+    public void ValidateSemaphoreName_WithTooLongValue_ShouldThrowArgumentException()
+    {
+        // Arrange
+        string semaphoreName = new('a', 256);
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateSemaphoreName(semaphoreName));
+        exception.ParamName.ShouldBe("semaphoreName");
+        exception.Message.ShouldContain("cannot exceed 255 characters");
+    }
+
+    [Theory]
+    [InlineData("semaphore with spaces")]
+    [InlineData("semaphore@invalid")]
+    [InlineData("semaphore#invalid")]
+    public void ValidateSemaphoreName_WithInvalidCharacters_ShouldThrowArgumentException(string invalidName)
+    {
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateSemaphoreName(invalidName));
+        exception.ParamName.ShouldBe("semaphoreName");
+        exception.Message.ShouldContain("invalid characters");
+    }
+
+    // ValidateHolderId tests
+
+    [Fact]
+    public void ValidateHolderId_WithValidValue_ShouldNotThrow()
+    {
+        // Arrange
+        const string validHolderId = "valid-holder_id.123";
+
+        // Act & Assert
+        Should.NotThrow(() => ParameterValidation.ValidateHolderId(validHolderId));
+    }
+
+    [Fact]
+    public void ValidateHolderId_WithNull_ShouldThrowArgumentException()
+    {
+        // Arrange
+        string? holderId = null;
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateHolderId(holderId!));
+        exception.ParamName.ShouldBe("holderId");
+        exception.Message.ShouldContain("cannot be null, empty, or whitespace");
+    }
+
+    [Fact]
+    public void ValidateHolderId_WithEmptyString_ShouldThrowArgumentException()
+    {
+        // Arrange
+        const string holderId = "";
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateHolderId(holderId));
+        exception.ParamName.ShouldBe("holderId");
+        exception.Message.ShouldContain("cannot be null, empty, or whitespace");
+    }
+
+    [Fact]
+    public void ValidateHolderId_WithTooLongValue_ShouldThrowArgumentException()
+    {
+        // Arrange
+        string holderId = new('a', 256);
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateHolderId(holderId));
+        exception.ParamName.ShouldBe("holderId");
+        exception.Message.ShouldContain("cannot exceed 255 characters");
+    }
+
+    [Fact]
+    public void ValidateHolderId_WithInvalidCharacters_ShouldThrowArgumentException()
+    {
+        // Arrange
+        const string holderId = "holder with spaces";
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateHolderId(holderId));
+        exception.ParamName.ShouldBe("holderId");
+        exception.Message.ShouldContain("invalid characters");
+    }
+
+    // ValidateMaxCount tests
+
+    [Fact]
+    public void ValidateMaxCount_WithValidValue_ShouldNotThrow()
+    {
+        // Arrange
+        const int maxCount = 5;
+
+        // Act & Assert
+        Should.NotThrow(() => ParameterValidation.ValidateMaxCount(maxCount));
+    }
+
+    [Fact]
+    public void ValidateMaxCount_WithOne_ShouldNotThrow()
+    {
+        // Arrange
+        const int maxCount = 1;
+
+        // Act & Assert
+        Should.NotThrow(() => ParameterValidation.ValidateMaxCount(maxCount));
+    }
+
+    [Fact]
+    public void ValidateMaxCount_WithMaxValue_ShouldNotThrow()
+    {
+        // Arrange
+        const int maxCount = 10000;
+
+        // Act & Assert
+        Should.NotThrow(() => ParameterValidation.ValidateMaxCount(maxCount));
+    }
+
+    [Fact]
+    public void ValidateMaxCount_WithZero_ShouldThrowArgumentException()
+    {
+        // Arrange
+        const int maxCount = 0;
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateMaxCount(maxCount));
+        exception.ParamName.ShouldBe("maxCount");
+        exception.Message.ShouldContain("must be at least 1");
+    }
+
+    [Fact]
+    public void ValidateMaxCount_WithNegative_ShouldThrowArgumentException()
+    {
+        // Arrange
+        const int maxCount = -1;
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateMaxCount(maxCount));
+        exception.ParamName.ShouldBe("maxCount");
+        exception.Message.ShouldContain("must be at least 1");
+    }
+
+    [Fact]
+    public void ValidateMaxCount_WithTooLargeValue_ShouldThrowArgumentException()
+    {
+        // Arrange
+        const int maxCount = 10001;
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateMaxCount(maxCount));
+        exception.ParamName.ShouldBe("maxCount");
+        exception.Message.ShouldContain("cannot exceed 10000");
+    }
+
+    // ValidateSlotTimeout tests
+
+    [Fact]
+    public void ValidateSlotTimeout_WithValidTimeout_ShouldNotThrow()
+    {
+        // Arrange
+        var slotTimeout = TimeSpan.FromMinutes(5);
+
+        // Act & Assert
+        Should.NotThrow(() => ParameterValidation.ValidateSlotTimeout(slotTimeout));
+    }
+
+    [Fact]
+    public void ValidateSlotTimeout_WithZero_ShouldThrowArgumentException()
+    {
+        // Arrange
+        TimeSpan slotTimeout = TimeSpan.Zero;
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateSlotTimeout(slotTimeout));
+        exception.ParamName.ShouldBe("slotTimeout");
+        exception.Message.ShouldContain("must be positive");
+    }
+
+    [Fact]
+    public void ValidateSlotTimeout_WithNegative_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var slotTimeout = TimeSpan.FromSeconds(-1);
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateSlotTimeout(slotTimeout));
+        exception.ParamName.ShouldBe("slotTimeout");
+        exception.Message.ShouldContain("must be positive");
+    }
+
+    [Fact]
+    public void ValidateSlotTimeout_WithMoreThanOneDay_ShouldThrowArgumentException()
+    {
+        // Arrange
+        TimeSpan slotTimeout = TimeSpan.FromDays(1) + TimeSpan.FromSeconds(1);
+
+        // Act & Assert
+        ArgumentException exception = Should.Throw<ArgumentException>(() =>
+            ParameterValidation.ValidateSlotTimeout(slotTimeout));
+        exception.ParamName.ShouldBe("slotTimeout");
+        exception.Message.ShouldContain("cannot exceed 1 day");
+    }
+
+    [Fact]
+    public void ValidateSlotTimeout_WithExactlyOneDay_ShouldNotThrow()
+    {
+        // Arrange
+        var slotTimeout = TimeSpan.FromDays(1);
+
+        // Act & Assert
+        Should.NotThrow(() => ParameterValidation.ValidateSlotTimeout(slotTimeout));
+    }
+
+    [Fact]
+    public void ValidateSlotTimeout_WithOneMillisecond_ShouldNotThrow()
+    {
+        // Arrange
+        var slotTimeout = TimeSpan.FromMilliseconds(1);
+
+        // Act & Assert
+        Should.NotThrow(() => ParameterValidation.ValidateSlotTimeout(slotTimeout));
+    }
+}
+

--- a/tests/MultiLock.Tests/SemaphoreServiceTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreServiceTests.cs
@@ -1,0 +1,352 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MultiLock.InMemory;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+public class SemaphoreServiceTests : IAsyncLifetime
+{
+    private readonly ILoggerFactory loggerFactory;
+    private readonly InMemorySemaphoreProvider provider;
+    private SemaphoreService? service;
+
+    public SemaphoreServiceTests()
+    {
+        loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        provider = new InMemorySemaphoreProvider(loggerFactory.CreateLogger<InMemorySemaphoreProvider>());
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (service != null)
+            await service.DisposeAsync();
+        provider.Dispose();
+        loggerFactory.Dispose();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreEmpty_ShouldSucceed()
+    {
+        // Arrange
+        service = CreateService("test-semaphore", 3);
+
+        // Act
+        bool acquired = await service.TryAcquireAsync();
+
+        // Assert
+        acquired.ShouldBeTrue();
+        service.IsHolding.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenSemaphoreFull_ShouldFail()
+    {
+        // Arrange
+        const int maxCount = 2;
+        service = CreateService("test-semaphore", maxCount);
+        var emptyMetadata = new Dictionary<string, string>();
+
+        // Fill the semaphore with other holders
+        await provider.TryAcquireAsync("test-semaphore", "other-1", maxCount, emptyMetadata, TimeSpan.FromMinutes(5));
+        await provider.TryAcquireAsync("test-semaphore", "other-2", maxCount, emptyMetadata, TimeSpan.FromMinutes(5));
+
+        // Act
+        bool acquired = await service.TryAcquireAsync();
+
+        // Assert
+        acquired.ShouldBeFalse();
+        service.IsHolding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_ShouldReleaseSlot()
+    {
+        // Arrange
+        service = CreateService("test-semaphore", 3);
+        await service.TryAcquireAsync();
+        service.IsHolding.ShouldBeTrue();
+
+        // Act
+        await service.ReleaseAsync();
+
+        // Assert
+        service.IsHolding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CurrentStatus_ShouldReflectHoldingState()
+    {
+        // Arrange
+        service = CreateService("test-semaphore", 3);
+
+        // Act & Assert - before acquiring
+        service.CurrentStatus.IsHolding.ShouldBeFalse();
+
+        await service.TryAcquireAsync();
+
+        // After acquiring
+        service.CurrentStatus.IsHolding.ShouldBeTrue();
+        service.CurrentStatus.CurrentCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task HolderId_ShouldBeSetFromOptions()
+    {
+        // Arrange
+        const string expectedHolderId = "custom-holder-id";
+        var options = new SemaphoreOptions
+        {
+            SemaphoreName = "test-semaphore",
+            MaxCount = 3,
+            HolderId = expectedHolderId,
+            AutoStart = false
+        };
+        service = new SemaphoreService(provider, Options.Create(options), loggerFactory.CreateLogger<SemaphoreService>());
+
+        // Assert
+        service.HolderId.ShouldBe(expectedHolderId);
+    }
+
+    [Fact]
+    public async Task SemaphoreName_ShouldBeSetFromOptions()
+    {
+        // Arrange
+        const string expectedName = "my-semaphore";
+        service = CreateService(expectedName, 3);
+
+        // Assert
+        service.SemaphoreName.ShouldBe(expectedName);
+    }
+
+    [Fact]
+    public async Task MaxCount_ShouldBeSetFromOptions()
+    {
+        // Arrange
+        const int expectedMaxCount = 5;
+        service = CreateService("test-semaphore", expectedMaxCount);
+
+        // Assert
+        service.MaxCount.ShouldBe(expectedMaxCount);
+    }
+
+    [Fact]
+    public async Task GetStatusChangesAsync_ShouldEmitEventsOnAcquire()
+    {
+        // Arrange
+        service = CreateService("test-semaphore", 3);
+        var events = new List<SemaphoreChangedEventArgs>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // Obtain the enumerator and advance it once. GetStatusChangesAsyncCoreImpl
+        // registers the subscriber channel synchronously (before its first await),
+        // so by the time MoveNextAsync() suspends the subscription is already in place.
+        // No Task.Delay is needed to coordinate ordering.
+        IAsyncEnumerator<SemaphoreChangedEventArgs> enumerator =
+            service.GetStatusChangesAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        ValueTask<bool> pendingMove = enumerator.MoveNextAsync();
+
+        // Act - subscription is registered; events produced here will be delivered.
+        await service.TryAcquireAsync();
+
+        // Drain events until we observe the holding transition.
+        try
+        {
+            while (await pendingMove)
+            {
+                events.Add(enumerator.Current);
+                if (enumerator.Current.CurrentStatus.IsHolding)
+                    break;
+                pendingMove = enumerator.MoveNextAsync();
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync();
+        }
+
+        // Assert
+        events.ShouldNotBeEmpty();
+        events.ShouldContain(e => e.CurrentStatus.IsHolding);
+    }
+
+    [Fact]
+    public async Task WaitForSlotAsync_WhenAlreadyHolding_ShouldReturnImmediately()
+    {
+        service = CreateService("test-semaphore", 3);
+        await service.TryAcquireAsync();
+        // Should return immediately without subscribing to events
+        await service.WaitForSlotAsync();
+        service.IsHolding.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task WaitForSlotAsync_WithTimeout_WhenSlotAcquired_ShouldReturnTrue()
+    {
+        service = CreateService("test-semaphore", 3);
+
+        // WaitForSlotAsync calls GetStatusChangesAsync internally. The implementation
+        // of GetStatusChangesAsyncCoreImpl registers the subscriber channel into
+        // subscriberChannels synchronously (before any await), so by the time the
+        // returned Task<bool> suspends the subscription is already in place.
+        // Calling TryAcquireAsync immediately after is therefore safe with no delay.
+        Task<bool> waitTask = service.WaitForSlotAsync(TimeSpan.FromSeconds(5));
+
+        await service.TryAcquireAsync();
+
+        bool result = await waitTask;
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task WaitForSlotAsync_WithTimeout_WhenTimeoutExpires_ShouldReturnFalse()
+    {
+        // Fill the semaphore so no slot is available
+        const int maxCount = 1;
+        service = CreateService("test-semaphore", maxCount);
+        var emptyMeta = new Dictionary<string, string>();
+        await provider.TryAcquireAsync("test-semaphore", "other", maxCount, emptyMeta, TimeSpan.FromMinutes(5));
+
+        // Try with a very short timeout — should return false
+        bool result = await service.WaitForSlotAsync(TimeSpan.FromMilliseconds(50));
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetSemaphoreInfoAsync_ShouldReturnCurrentInfo()
+    {
+        service = CreateService("test-semaphore", 5);
+        await service.TryAcquireAsync();
+
+        SemaphoreInfo? info = await service.GetSemaphoreInfoAsync();
+
+        info.ShouldNotBeNull();
+        info.SemaphoreName.ShouldBe("test-semaphore");
+        info.MaxCount.ShouldBe(5);
+        info.CurrentCount.ShouldBeGreaterThanOrEqualTo(1);
+        info.Holders.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenHolding_ShouldRelease()
+    {
+        service = CreateService("test-semaphore", 3);
+        await service.TryAcquireAsync();
+        service.IsHolding.ShouldBeTrue();
+
+        await service.StopAsync();
+
+        service.IsHolding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenNotHolding_ShouldNotThrow()
+    {
+        service = CreateService("test-semaphore", 3);
+        await Should.NotThrowAsync(() => service.StopAsync());
+    }
+
+    [Fact]
+    public async Task StartAsync_WithAutoStartFalse_ShouldNotAcquireSlot()
+    {
+        service = CreateService("test-semaphore", 3);
+        await service.StartAsync();
+        service.IsHolding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task StartAsync_WithAutoStartTrue_ShouldAcquireSlot()
+    {
+        var options = new SemaphoreOptions
+        {
+            SemaphoreName = "test-semaphore",
+            MaxCount = 3,
+            AutoStart = true,
+            HeartbeatInterval = TimeSpan.FromSeconds(10),
+            HeartbeatTimeout = TimeSpan.FromSeconds(30),
+            AcquisitionInterval = TimeSpan.FromSeconds(5)
+        };
+        service = new SemaphoreService(provider, Options.Create(options), loggerFactory.CreateLogger<SemaphoreService>());
+        await service.StartAsync();
+        service.IsHolding.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldNotThrow()
+    {
+        service = CreateService("test-semaphore", 3);
+        await Should.NotThrowAsync(() => service.DisposeAsync().AsTask());
+        service = null; // prevent double-dispose in teardown
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CalledMultipleTimes_ShouldNotThrow()
+    {
+        service = CreateService("test-semaphore", 3);
+        await service.DisposeAsync();
+        await Should.NotThrowAsync(() => service.DisposeAsync().AsTask());
+        service = null;
+    }
+
+    [Fact]
+    public void Dispose_ShouldNotThrow()
+    {
+        service = CreateService("test-semaphore", 3);
+        Should.NotThrow(() => service.Dispose());
+        service = null;
+    }
+
+    [Fact]
+    public async Task PublicMethods_AfterDispose_ShouldThrowObjectDisposedException()
+    {
+        service = CreateService("test-semaphore", 3);
+        await service.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => service.TryAcquireAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => service.ReleaseAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => service.WaitForSlotAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => service.WaitForSlotAsync(TimeSpan.FromSeconds(1)));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => service.GetSemaphoreInfoAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => service.StartAsync());
+        service = null;
+    }
+
+    [Fact]
+    public async Task WaitForSlotAsync_WhenServiceDisposedWhileWaiting_ShouldThrowObjectDisposedException()
+    {
+        // Fill the semaphore so WaitForSlotAsync must block waiting for a slot.
+        const int maxCount = 1;
+        service = CreateService("test-semaphore", maxCount);
+        var emptyMeta = new Dictionary<string, string>();
+        await provider.TryAcquireAsync("test-semaphore", "other", maxCount, emptyMeta, TimeSpan.FromMinutes(5));
+
+        Task waitTask = service.WaitForSlotAsync();
+
+        // Dispose while WaitForSlotAsync is blocking — it should unblock and throw.
+        await service.DisposeAsync();
+        service = null;
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => waitTask);
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_WhenNotHolding_ShouldBeNoOp()
+    {
+        service = CreateService("test-semaphore", 3);
+        // Should not throw; IsHolding stays false
+        await service.ReleaseAsync();
+        service.IsHolding.ShouldBeFalse();
+    }
+
+    private SemaphoreService CreateService(string semaphoreName, int maxCount) =>
+        new(provider, Options.Create(new SemaphoreOptions
+        {
+            SemaphoreName = semaphoreName,
+            MaxCount = maxCount,
+            AutoStart = false
+        }), loggerFactory.CreateLogger<SemaphoreService>());
+}
+

--- a/tests/MultiLock.Tests/SemaphoreServiceTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreServiceTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
 using MultiLock.InMemory;
 using Shouldly;
 using Xunit;
@@ -377,6 +379,91 @@ public class SemaphoreServiceTests : IAsyncLifetime
         // Assert
         scope.ShouldBeNull();
         service.IsHolding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task WaitForSlotAsync_WhenSlotBecomesAvailable_ReturnsOnceAcquired()
+    {
+        // Arrange: not holding yet; begin waiting (subscription is registered synchronously).
+        service = CreateService("test-semaphore", 1);
+        Task waitTask = service.WaitForSlotAsync();
+
+        // Act: acquiring broadcasts an AcquiredSlot transition that the waiter observes.
+        (await service.TryAcquireAsync()).ShouldBeTrue();
+
+        // Assert: the wait completes promptly rather than blocking forever.
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
+        service.IsHolding.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenProviderThrowsTransiently_RetriesThenSucceeds()
+    {
+        // Arrange: provider fails twice then succeeds, exercising the retry + backoff path.
+        var mockProvider = new Mock<ISemaphoreProvider>();
+        mockProvider.SetupSequence(p => p.TryAcquireAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("transient-1"))
+            .ThrowsAsync(new InvalidOperationException("transient-2"))
+            .ReturnsAsync(true);
+        mockProvider.Setup(p => p.GetCurrentCountAsync(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        await using var svc = new SemaphoreService(
+            mockProvider.Object,
+            Options.Create(new SemaphoreOptions
+            {
+                SemaphoreName = "retry-semaphore",
+                MaxCount = 1,
+                AutoStart = false,
+                MaxRetryAttempts = 3,
+                RetryBaseDelay = TimeSpan.FromMilliseconds(1),
+                RetryMaxDelay = TimeSpan.FromMilliseconds(10),
+                EnableDetailedLogging = true
+            }),
+            NullLogger<SemaphoreService>.Instance);
+
+        // Act
+        bool acquired = await svc.TryAcquireAsync();
+
+        // Assert: succeeded on the third attempt.
+        acquired.ShouldBeTrue();
+        mockProvider.Verify(p => p.TryAcquireAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+            It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenProviderAlwaysThrows_RethrowsAfterExhaustingRetries()
+    {
+        // Arrange: provider always throws; the service should retry then surface the last exception.
+        var mockProvider = new Mock<ISemaphoreProvider>();
+        mockProvider.Setup(p => p.TryAcquireAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        await using var svc = new SemaphoreService(
+            mockProvider.Object,
+            Options.Create(new SemaphoreOptions
+            {
+                SemaphoreName = "retry-semaphore",
+                MaxCount = 1,
+                AutoStart = false,
+                MaxRetryAttempts = 2,
+                RetryBaseDelay = TimeSpan.FromMilliseconds(1),
+                RetryMaxDelay = TimeSpan.FromMilliseconds(10)
+            }),
+            NullLogger<SemaphoreService>.Instance);
+
+        // Act & Assert: the original exception propagates after MaxRetryAttempts + 1 tries.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.TryAcquireAsync());
+        mockProvider.Verify(p => p.TryAcquireAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+            It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
     }
 
     private SemaphoreService CreateService(string semaphoreName, int maxCount) =>

--- a/tests/MultiLock.Tests/SemaphoreServiceTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreServiceTests.cs
@@ -341,6 +341,44 @@ public class SemaphoreServiceTests : IAsyncLifetime
         service.IsHolding.ShouldBeFalse();
     }
 
+    [Fact]
+    public async Task AcquireScopeAsync_WhenSlotAvailable_ReturnsScopeAndReleasesOnDispose()
+    {
+        // Arrange
+        service = CreateService("test-semaphore", 1);
+
+        // Act
+        SemaphoreAcquisition? scope = await service.AcquireScopeAsync();
+
+        // Assert: the scope reflects a held slot.
+        scope.ShouldNotBeNull();
+        scope!.HolderId.ShouldBe(service.HolderId);
+        service.IsHolding.ShouldBeTrue();
+        (await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromSeconds(30))).ShouldBe(1);
+
+        // Disposing the scope releases through the service.
+        await scope.DisposeAsync();
+
+        service.IsHolding.ShouldBeFalse();
+        (await provider.GetCurrentCountAsync("test-semaphore", TimeSpan.FromSeconds(30))).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task AcquireScopeAsync_WhenSemaphoreFull_ReturnsNull()
+    {
+        // Arrange
+        const int maxCount = 1;
+        service = CreateService("test-semaphore", maxCount);
+        await provider.TryAcquireAsync("test-semaphore", "other-1", maxCount, new Dictionary<string, string>(), TimeSpan.FromMinutes(5));
+
+        // Act
+        SemaphoreAcquisition? scope = await service.AcquireScopeAsync();
+
+        // Assert
+        scope.ShouldBeNull();
+        service.IsHolding.ShouldBeFalse();
+    }
+
     private SemaphoreService CreateService(string semaphoreName, int maxCount) =>
         new(provider, Options.Create(new SemaphoreOptions
         {

--- a/tests/MultiLock.Tests/SemaphoreServiceTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreServiceTests.cs
@@ -466,6 +466,74 @@ public class SemaphoreServiceTests : IAsyncLifetime
             Times.Exactly(3));
     }
 
+    [Fact]
+    public async Task AutoStart_HeartbeatTimerFires_KeepsSlotHeld()
+    {
+        // Arrange: short heartbeat interval so the heartbeat timer callback actually fires.
+        var options = new SemaphoreOptions
+        {
+            SemaphoreName = "heartbeat-semaphore",
+            MaxCount = 1,
+            AutoStart = true,
+            HeartbeatInterval = TimeSpan.FromMilliseconds(50),
+            HeartbeatTimeout = TimeSpan.FromMilliseconds(250),
+            AcquisitionInterval = TimeSpan.FromMilliseconds(50),
+            EnableDetailedLogging = true
+        };
+        service = new SemaphoreService(provider, Options.Create(options), loggerFactory.CreateLogger<SemaphoreService>());
+
+        // Act: AutoStart acquires immediately, then the heartbeat timer renews the slot repeatedly.
+        await service.StartAsync();
+        await WaitUntilAsync(() => service.IsHolding, TimeSpan.FromSeconds(5));
+
+        // Assert: after several heartbeat intervals the slot is still held (renewals succeeded).
+        await Task.Delay(250);
+        service.IsHolding.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AutoStart_WhenInitiallyFull_AcquisitionTimerAcquiresOnceSlotFrees()
+    {
+        // Arrange: occupy the only slot, then start an auto-starting service that must wait.
+        const string semaphore = "acquisition-semaphore";
+        var meta = new Dictionary<string, string>();
+        await provider.TryAcquireAsync(semaphore, "other-holder", 1, meta, TimeSpan.FromMinutes(5));
+
+        var options = new SemaphoreOptions
+        {
+            SemaphoreName = semaphore,
+            MaxCount = 1,
+            AutoStart = true,
+            HeartbeatInterval = TimeSpan.FromMilliseconds(50),
+            HeartbeatTimeout = TimeSpan.FromMilliseconds(250),
+            AcquisitionInterval = TimeSpan.FromMilliseconds(50)
+        };
+        service = new SemaphoreService(provider, Options.Create(options), loggerFactory.CreateLogger<SemaphoreService>());
+
+        // Act: the acquisition timer keeps retrying while the semaphore is full.
+        await service.StartAsync();
+        await Task.Delay(150);
+        service.IsHolding.ShouldBeFalse();
+
+        // Free the slot; the acquisition timer should pick it up on a subsequent tick.
+        await provider.ReleaseAsync(semaphore, "other-holder");
+
+        // Assert
+        await WaitUntilAsync(() => service.IsHolding, TimeSpan.FromSeconds(5));
+        service.IsHolding.ShouldBeTrue();
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        while (!condition())
+        {
+            if (cts.IsCancellationRequested)
+                throw new TimeoutException("Condition was not met within the allotted time.");
+            await Task.Delay(20);
+        }
+    }
+
     private SemaphoreService CreateService(string semaphoreName, int maxCount) =>
         new(provider, Options.Create(new SemaphoreOptions
         {

--- a/tests/MultiLock.Tests/SemaphoreServiceTests.cs
+++ b/tests/MultiLock.Tests/SemaphoreServiceTests.cs
@@ -96,7 +96,7 @@ public class SemaphoreServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HolderId_ShouldBeSetFromOptions()
+    public void HolderId_ShouldBeSetFromOptions()
     {
         // Arrange
         const string expectedHolderId = "custom-holder-id";
@@ -114,7 +114,7 @@ public class SemaphoreServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task SemaphoreName_ShouldBeSetFromOptions()
+    public void SemaphoreName_ShouldBeSetFromOptions()
     {
         // Arrange
         const string expectedName = "my-semaphore";
@@ -125,7 +125,7 @@ public class SemaphoreServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task MaxCount_ShouldBeSetFromOptions()
+    public void MaxCount_ShouldBeSetFromOptions()
     {
         // Arrange
         const int expectedMaxCount = 5;
@@ -379,6 +379,45 @@ public class SemaphoreServiceTests : IAsyncLifetime
         // Assert
         scope.ShouldBeNull();
         service.IsHolding.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task StopAsync_ShouldCompleteActiveStatusEnumerations()
+    {
+        // A GetStatusChangesAsync consumer blocks on its own subscriber channel; StopAsync must
+        // complete it so the enumeration ends rather than hanging until disposal.
+        service = CreateService("stop-semaphore", 1);
+
+        Task enumerationTask = Task.Run(async () =>
+        {
+            await foreach (SemaphoreChangedEventArgs _ in service.GetStatusChangesAsync())
+            {
+                // drain
+            }
+        });
+
+        await Task.Delay(100); // let the enumerator register its subscriber channel
+        await service.StopAsync();
+
+        // Completes promptly once StopAsync completes the subscriber channel.
+        await enumerationTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task StopAsync_ShouldUnblockWaitForSlotWaiter()
+    {
+        // Occupy the only slot so the (manual) service cannot acquire and WaitForSlotAsync blocks.
+        service = CreateService("stop-semaphore-2", 1);
+        await provider.TryAcquireAsync("stop-semaphore-2", "other-holder", 1, new Dictionary<string, string>(), TimeSpan.FromMinutes(5));
+
+        Task waitTask = service.WaitForSlotAsync();
+        await Task.Delay(100);
+
+        await service.StopAsync();
+
+        // The waiter is released (the channel completes without an acquisition) and surfaces a stop
+        // rather than hanging indefinitely.
+        await Should.ThrowAsync<ObjectDisposedException>(() => waitTask.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
     [Fact]

--- a/tests/MultiLock.Tests/ServiceExtensionsValidationTests.cs
+++ b/tests/MultiLock.Tests/ServiceExtensionsValidationTests.cs
@@ -198,5 +198,85 @@ public class ServiceExtensionsValidationTests
 
         ILeaderElectionProvider Factory(IServiceProvider sp) => new InMemoryLeaderElectionProvider(sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<InMemoryLeaderElectionProvider>>());
     }
+
+    // AddSemaphore tests
+
+    [Fact]
+    public void AddSemaphore_WithNullServices_ShouldThrowArgumentNullException()
+    {
+        IServiceCollection? services = null;
+        Should.Throw<ArgumentNullException>(() => services!.AddSemaphore())
+            .ParamName.ShouldBe("services");
+    }
+
+    [Fact]
+    public void AddSemaphore_WithValidServices_ShouldSucceed()
+    {
+        var services = new ServiceCollection();
+        IServiceCollection result = services.AddSemaphore();
+        result.ShouldBe(services);
+    }
+
+    [Fact]
+    public void AddSemaphore_WithConfigureOptions_ShouldSucceed()
+    {
+        var services = new ServiceCollection();
+        IServiceCollection result = services.AddSemaphore(o => o.SemaphoreName = "test");
+        result.ShouldBe(services);
+    }
+
+    [Fact]
+    public void AddSemaphoreGeneric_WithNullServices_ShouldThrowArgumentNullException()
+    {
+        IServiceCollection? services = null;
+        Should.Throw<ArgumentNullException>(() => services!.AddSemaphore<InMemory.InMemorySemaphoreProvider>())
+            .ParamName.ShouldBe("services");
+    }
+
+    [Fact]
+    public void AddSemaphoreGeneric_WithValidServices_ShouldRegisterProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSemaphore<InMemory.InMemorySemaphoreProvider>(o => o.SemaphoreName = "test-sem");
+
+        ServiceProvider sp = services.BuildServiceProvider();
+        sp.GetService<ISemaphoreProvider>().ShouldNotBeNull();
+        sp.GetService<ISemaphoreService>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddSemaphoreWithFactory_WithNullServices_ShouldThrowArgumentNullException()
+    {
+        IServiceCollection? services = null;
+        Should.Throw<ArgumentNullException>(
+            () => services!.AddSemaphore(sp => new InMemory.InMemorySemaphoreProvider(
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<InMemory.InMemorySemaphoreProvider>>())))
+            .ParamName.ShouldBe("services");
+    }
+
+    [Fact]
+    public void AddSemaphoreWithFactory_WithNullFactory_ShouldThrowArgumentNullException()
+    {
+        var services = new ServiceCollection();
+        Func<IServiceProvider, ISemaphoreProvider>? factory = null;
+        Should.Throw<ArgumentNullException>(() => services.AddSemaphore(factory!))
+            .ParamName.ShouldBe("providerFactory");
+    }
+
+    [Fact]
+    public void AddSemaphoreWithFactory_WithValidFactory_ShouldRegisterService()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSemaphore(
+            sp => new InMemory.InMemorySemaphoreProvider(
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<InMemory.InMemorySemaphoreProvider>>()),
+            o => o.SemaphoreName = "test-sem");
+
+        ServiceProvider sp2 = services.BuildServiceProvider();
+        sp2.GetService<ISemaphoreProvider>().ShouldNotBeNull();
+        sp2.GetService<ISemaphoreService>().ShouldNotBeNull();
+    }
 }
 

--- a/tests/MultiLock.Tests/ZooKeeperSemaphoreNodeOrderingTests.cs
+++ b/tests/MultiLock.Tests/ZooKeeperSemaphoreNodeOrderingTests.cs
@@ -1,0 +1,59 @@
+using MultiLock.ZooKeeper;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+public class ZooKeeperSemaphoreNodeOrderingTests
+{
+    [Theory]
+    [InlineData("holder1-0000000000", 0)]
+    [InlineData("holder1-0000000042", 42)]
+    [InlineData("zzz-0000000001", 1)]
+    [InlineData("my-holder.01-0000000005", 5)]
+    public void GetSequenceNumber_WithSequentialNodeName_ReturnsSequenceSuffix(string nodeName, long expected)
+    {
+        ZooKeeperSemaphoreProvider.GetSequenceNumber(nodeName).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("no-sequence-suffix")]
+    [InlineData("trailing-hyphen-")]
+    [InlineData("nohyphen")]
+    [InlineData("")]
+    [InlineData("holder-+42")]
+    [InlineData("holder- 42")]
+    [InlineData("holder-42 ")]
+    public void GetSequenceNumber_WithUnparsableName_SortsLast(string nodeName)
+    {
+        ZooKeeperSemaphoreProvider.GetSequenceNumber(nodeName).ShouldBe(long.MaxValue);
+    }
+
+    [Fact]
+    public void OrderingBySequence_ReflectsCreationOrder_NotHolderIdSort()
+    {
+        // "zzz" acquired first (sequence 1), "aaa" second (sequence 2). A lexicographic sort of
+        // the full node names would put "aaa" first and let a later creator rank itself within
+        // maxCount ahead of an established holder; sequence order must win.
+        var children = new List<string> { "aaa-0000000002", "zzz-0000000001" };
+
+        List<string> sorted = children.OrderBy(ZooKeeperSemaphoreProvider.GetSequenceNumber).ToList();
+
+        sorted.ShouldBe(new[] { "zzz-0000000001", "aaa-0000000002" });
+    }
+
+    [Fact]
+    public void OrderingBySequence_WithHyphenatedHolderIds_UsesLastHyphenSuffix()
+    {
+        var children = new List<string>
+        {
+            "web-worker-2-0000000003",
+            "api-node-1-0000000001",
+            "web-worker-1-0000000002"
+        };
+
+        List<string> sorted = children.OrderBy(ZooKeeperSemaphoreProvider.GetSequenceNumber).ToList();
+
+        sorted.ShouldBe(new[] { "api-node-1-0000000001", "web-worker-1-0000000002", "web-worker-2-0000000003" });
+    }
+}


### PR DESCRIPTION
Implement a distributed counting semaphore abstraction (ISemaphoreService / ISemaphoreProvider) mirroring the existing leader-election design, with providers for PostgreSQL, SQL Server, Redis, Azure Blob Storage, Consul, ZooKeeper, FileSystem, and InMemory.

Key design decisions and fixes included in this commit:

- AutoStart=false defers acquisition to the caller; StartAsync drives acquisition when true; ExecuteAsync is a no-op stub (BackgroundService requirement)
- GetCurrentCountAsync filters by heartbeat age (slotTimeout) so expired holders are excluded from the live count across all providers
- PostgreSQL uses pg_advisory_xact_lock(hashtext(semaphoreName)) under ReadCommitted instead of SERIALIZABLE + FOR UPDATE, which deadlocked on empty tables
- SQL Server uses sp_getapplock(@Resource, 'Exclusive', 'Transaction') under ReadCommitted instead of SERIALIZABLE + range locks, which caused deadlocks when the table was empty
- Consul and ZooKeeper apply a post-acquisition count recheck to close the TOCTOU window between the count read and the slot creation
- FileSystem provider validates canonical paths to prevent directory traversal via semaphoreName or holderId
- Schema and table names are validated against ^[a-zA-Z_][a-zA-Z0-9_]*$ (max 128 chars) before interpolation into SQL to prevent injection
- InMemory provider replaced ConcurrentDictionary with plain Dictionary guarded by a single lock, removing redundant thread-safety layering
- SemaphoreAcquisition.Dispose() delegates to DisposeAsync() to avoid sync-context deadlocks from direct GetAwaiter().GetResult() on the task
- SemaphoreService.DisposeAsync() awaits broadcastTask before completing
- UpdateStatus() is a plain void method; the previous async overload only awaited Task.CompletedTask and accepted an unused CancellationToken
- HeartbeatTimeout (not the now-removed SlotTimeout) is passed as the expiry window to all provider calls
- IAsyncDisposable removed from SemaphoreService class declaration (already satisfied via ISemaphoreService)
- CurrentCount decrements are guarded with Math.Max(0, ...) to prevent negative counts on spurious releases
- Integration tests: each test instance uses a unique table name and semaphore name (Guid-per-instance); DisposeAsync drops the table; ConcurrentAcquire asserts successCount == maxCount and cross-checks via GetCurrentCountAsync

Fixes #100