### PR TITLE
fix(zookeeper): order semaphore nodes by sequence number, not node name

### DIFF
--- a/src/Providers/MultiLock.ZooKeeper/MultiLock.ZooKeeper.csproj
+++ b/src/Providers/MultiLock.ZooKeeper/MultiLock.ZooKeeper.csproj
@@ -14,6 +14,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="MultiLock.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
     <ProjectReference Include="..\..\MultiLock\MultiLock.csproj">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
       <IncludeAssets>MultiLock.dll</IncludeAssets>

--- a/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
@@ -610,13 +610,19 @@ public sealed class ZooKeeperSemaphoreProvider : Watcher, ISemaphoreProvider, IA
 
     // Extracts the ZooKeeper-assigned sequence number from a sequential node name of the form
     // "{holderId}-{seq}". Holder IDs may themselves contain hyphens, so take the suffix after the
-    // LAST hyphen. Nodes whose suffix cannot be parsed (unexpected foreign nodes) sort last so
-    // they can never displace a validly created holder from its position.
+    // LAST hyphen. NumberStyles.None restricts the suffix to plain ASCII digits (no sign or
+    // whitespace), matching ZooKeeper's zero-padded suffix format exactly. Nodes whose suffix does
+    // not parse under those rules (unexpected foreign nodes) sort last so they can never displace
+    // a validly created holder from its position.
     internal static long GetSequenceNumber(string nodeName)
     {
         int separatorIndex = nodeName.LastIndexOf('-');
         if (separatorIndex >= 0 && separatorIndex < nodeName.Length - 1
-            && long.TryParse(nodeName[(separatorIndex + 1)..], out long sequence))
+            && long.TryParse(
+                nodeName.AsSpan(separatorIndex + 1),
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out long sequence))
         {
             return sequence;
         }

--- a/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.ZooKeeper/ZooKeeperSemaphoreProvider.cs
@@ -106,7 +106,13 @@ public sealed class ZooKeeperSemaphoreProvider : Watcher, ISemaphoreProvider, IA
 
             // Verify we're within the limit (race condition check)
             children = await zooKeeper.getChildrenAsync(semaphorePath);
-            var sortedChildren = children.Children.OrderBy(c => c).ToList();
+            // Order by the ZooKeeper-assigned sequence suffix, NOT the full node name: names are
+            // "{holderId}-{seq}", so a lexicographic sort is dominated by the holder ID and does
+            // not reflect creation order. Sorting by name would let a later creator whose ID sorts
+            // before an established holder's rank itself within maxCount and be admitted, pushing
+            // the live holder count past the limit. Sequence order makes the position check match
+            // actual acquisition order so exactly the first maxCount creators keep their slots.
+            var sortedChildren = children.Children.OrderBy(GetSequenceNumber).ToList();
             string createdNodeName = createdPath[(createdPath.LastIndexOf('/') + 1)..];
             int position = sortedChildren.IndexOf(createdNodeName);
 
@@ -600,6 +606,22 @@ public sealed class ZooKeeperSemaphoreProvider : Watcher, ISemaphoreProvider, IA
     private string GetSemaphorePath(string semaphoreName)
     {
         return $"{options.RootPath}/{semaphoreName}";
+    }
+
+    // Extracts the ZooKeeper-assigned sequence number from a sequential node name of the form
+    // "{holderId}-{seq}". Holder IDs may themselves contain hyphens, so take the suffix after the
+    // LAST hyphen. Nodes whose suffix cannot be parsed (unexpected foreign nodes) sort last so
+    // they can never displace a validly created holder from its position.
+    internal static long GetSequenceNumber(string nodeName)
+    {
+        int separatorIndex = nodeName.LastIndexOf('-');
+        if (separatorIndex >= 0 && separatorIndex < nodeName.Length - 1
+            && long.TryParse(nodeName[(separatorIndex + 1)..], out long sequence))
+        {
+            return sequence;
+        }
+
+        return long.MaxValue;
     }
 
     private string? GetExistingNode(string semaphoreName, string holderId)

--- a/tests/MultiLock.Tests/ZooKeeperSemaphoreNodeOrderingTests.cs
+++ b/tests/MultiLock.Tests/ZooKeeperSemaphoreNodeOrderingTests.cs
@@ -1,0 +1,56 @@
+using MultiLock.ZooKeeper;
+using Shouldly;
+using Xunit;
+
+namespace MultiLock.Tests;
+
+public class ZooKeeperSemaphoreNodeOrderingTests
+{
+    [Theory]
+    [InlineData("holder1-0000000000", 0)]
+    [InlineData("holder1-0000000042", 42)]
+    [InlineData("zzz-0000000001", 1)]
+    [InlineData("my-holder.01-0000000005", 5)]
+    public void GetSequenceNumber_WithSequentialNodeName_ReturnsSequenceSuffix(string nodeName, long expected)
+    {
+        ZooKeeperSemaphoreProvider.GetSequenceNumber(nodeName).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("no-sequence-suffix")]
+    [InlineData("trailing-hyphen-")]
+    [InlineData("nohyphen")]
+    [InlineData("")]
+    public void GetSequenceNumber_WithUnparsableName_SortsLast(string nodeName)
+    {
+        ZooKeeperSemaphoreProvider.GetSequenceNumber(nodeName).ShouldBe(long.MaxValue);
+    }
+
+    [Fact]
+    public void OrderingBySequence_ReflectsCreationOrder_NotHolderIdSort()
+    {
+        // "zzz" acquired first (sequence 1), "aaa" second (sequence 2). A lexicographic sort of
+        // the full node names would put "aaa" first and let a later creator rank itself within
+        // maxCount ahead of an established holder; sequence order must win.
+        var children = new List<string> { "aaa-0000000002", "zzz-0000000001" };
+
+        List<string> sorted = children.OrderBy(ZooKeeperSemaphoreProvider.GetSequenceNumber).ToList();
+
+        sorted.ShouldBe(new[] { "zzz-0000000001", "aaa-0000000002" });
+    }
+
+    [Fact]
+    public void OrderingBySequence_WithHyphenatedHolderIds_UsesLastHyphenSuffix()
+    {
+        var children = new List<string>
+        {
+            "web-worker-2-0000000003",
+            "api-node-1-0000000001",
+            "web-worker-1-0000000002"
+        };
+
+        List<string> sorted = children.OrderBy(ZooKeeperSemaphoreProvider.GetSequenceNumber).ToList();
+
+        sorted.ShouldBe(new[] { "api-node-1-0000000001", "web-worker-1-0000000002", "web-worker-2-0000000003" });
+    }
+}

--- a/tests/MultiLock.Tests/ZooKeeperSemaphoreNodeOrderingTests.cs
+++ b/tests/MultiLock.Tests/ZooKeeperSemaphoreNodeOrderingTests.cs
@@ -21,6 +21,9 @@ public class ZooKeeperSemaphoreNodeOrderingTests
     [InlineData("trailing-hyphen-")]
     [InlineData("nohyphen")]
     [InlineData("")]
+    [InlineData("holder-+42")]
+    [InlineData("holder- 42")]
+    [InlineData("holder-42 ")]
     public void GetSequenceNumber_WithUnparsableName_SortsLast(string nodeName)
     {
         ZooKeeperSemaphoreProvider.GetSequenceNumber(nodeName).ShouldBe(long.MaxValue);


### PR DESCRIPTION
Fixes an over-admission bug found during review of #117.

## Problem

The post-create race check in `ZooKeeperSemaphoreProvider.TryAcquireAsync` sorted children lexicographically (`OrderBy(c => c)`). Sequential nodes are named `{holderId}-{seq}`, so the sort was dominated by the **holder ID** rather than the ZooKeeper-assigned sequence number, and a node's position no longer reflected creation order.

Concrete failure with `maxCount = 1`:

1. Holder `zzz` lists children (empty), creates `zzz-0000000001`, verifies — sees only itself at position 0 → admitted.
2. Holder `aaa`, whose pre-check read children before zzz's create committed, creates `aaa-0000000002`, then verifies — sorted children are `[aaa-0000000002, zzz-0000000001]`, so it computes position 0 → **also admitted**. Two live holders with `maxCount = 1`.

With correct sequence ordering, `aaa` (created later) computes position 1 and rolls back.

## Fix

- Sort children by the numeric sequence suffix after the **last** hyphen (`GetSequenceNumber`), since holder IDs may themselves contain hyphens. The position check now matches actual acquisition order, so exactly the first `maxCount` creators keep their slots.
- Unparsable names sort last (`long.MaxValue`), so an unexpected foreign node can never displace a validly created holder.

## Tests

- New `ZooKeeperSemaphoreNodeOrderingTests` covering suffix parsing (plain and hyphenated holder IDs), the unparsable-name fallback, and the exact admission-order scenario above.
- Made `GetSequenceNumber` `internal` and added `InternalsVisibleTo("MultiLock.Tests")` to `MultiLock.ZooKeeper` so the ordering logic is unit-testable without a live ZooKeeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D79i3saTKrBEKrhpMuDWv

---
_Generated by [Claude Code](https://claude.ai/code/session_011D79i3saTKrBEKrhpMuDWv)_