### PR TITLE
fix(semaphore): harden Consul, Redis, and SQL Server providers

### DIFF
--- a/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Consul/ConsulSemaphoreProvider.cs
@@ -83,10 +83,23 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
                 // Renew the session, but only treat this as a successful renewal if the holder key
                 // still exists. The session can outlive its key (e.g. the key was deleted out of
                 // band), in which case the slot is genuinely lost and we must re-acquire rather than
-                // falsely report success.
-                WriteResult<SessionEntry>? renewResult = await consulClient.Session.Renew(existingSessionId, cancellationToken);
-                if (renewResult.Response != null
-                    && await UpdateHolderKeyAsync(semaphoreName, holderId, existingSessionId, metadata, cancellationToken))
+                // falsely report success. Session.Renew THROWS SessionExpiredException (rather than
+                // returning a null response) when the session no longer exists, so treat that the
+                // same as a failed renewal and fall through to the re-acquire path below.
+                bool renewed = false;
+                try
+                {
+                    WriteResult<SessionEntry>? renewResult = await consulClient.Session.Renew(existingSessionId, cancellationToken);
+                    renewed = renewResult.Response != null
+                        && await UpdateHolderKeyAsync(semaphoreName, holderId, existingSessionId, metadata, cancellationToken);
+                }
+                catch (SessionExpiredException ex)
+                {
+                    logger.LogWarning(ex, "Consul session {SessionId} for holder {HolderId} in semaphore {SemaphoreName} has expired",
+                        existingSessionId, holderId, semaphoreName);
+                }
+
+                if (renewed)
                 {
                     logger.LogInformation("Renewed slot for holder {HolderId} in semaphore {SemaphoreName}",
                         holderId, semaphoreName);
@@ -259,7 +272,24 @@ public sealed class ConsulSemaphoreProvider : ISemaphoreProvider, IAsyncDisposab
                 return false;
             }
 
-            WriteResult<SessionEntry>? renewResult = await consulClient.Session.Renew(sessionId, cancellationToken);
+            // Session.Renew THROWS SessionExpiredException (rather than returning a null response)
+            // when the session no longer exists, e.g. after a network partition longer than the TTL.
+            // It must be reported as a failed heartbeat (false), not as a provider error: an
+            // exception here would be retried and logged by the service while it keeps believing it
+            // holds a slot it has permanently lost.
+            WriteResult<SessionEntry>? renewResult;
+            try
+            {
+                renewResult = await consulClient.Session.Renew(sessionId, cancellationToken);
+            }
+            catch (SessionExpiredException ex)
+            {
+                RemoveSession(semaphoreName, holderId);
+                logger.LogWarning(ex, "Consul session {SessionId} for holder {HolderId} in semaphore {SemaphoreName} has expired - slot lost",
+                    sessionId, holderId, semaphoreName);
+                return false;
+            }
+
             if (renewResult.Response == null)
             {
                 RemoveSession(semaphoreName, holderId);

--- a/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.Redis/RedisSemaphoreProvider.cs
@@ -376,14 +376,18 @@ public sealed class RedisSemaphoreProvider : ISemaphoreProvider
         return connectionMultiplexer.Value.GetDatabase(options.Database);
     }
 
+    // The "{prefix:name}" hash tag forces both of a semaphore's keys into the same Redis Cluster
+    // hash slot. Without it, the holders and data keys hash to different slots and every multi-key
+    // Lua script (acquire/release/heartbeat) fails with CROSSSLOT on clustered deployments.
+    // Harmless on standalone Redis, where the braces are just part of the key name.
     private string GetHoldersKey(string semaphoreName)
     {
-        return $"{options.KeyPrefix}:{semaphoreName}:holders";
+        return $"{{{options.KeyPrefix}:{semaphoreName}}}:holders";
     }
 
     private string GetDataKey(string semaphoreName)
     {
-        return $"{options.KeyPrefix}:{semaphoreName}:data";
+        return $"{{{options.KeyPrefix}:{semaphoreName}}}:data";
     }
 
     /// <summary>

--- a/src/Providers/MultiLock.SqlServer/SqlServerSemaphoreProvider.cs
+++ b/src/Providers/MultiLock.SqlServer/SqlServerSemaphoreProvider.cs
@@ -183,6 +183,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
                 throw;
             }
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error acquiring slot for holder {HolderId} in semaphore {SemaphoreName}",
@@ -220,6 +224,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
 
             logger.LogInformation("Released slot for holder {HolderId} in semaphore {SemaphoreName}. Rows affected: {RowsAffected}",
                 holderId, semaphoreName, rowsAffected);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -265,6 +273,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
             int rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
             return rowsAffected > 0;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error updating heartbeat for holder {HolderId} in semaphore {SemaphoreName}",
@@ -301,6 +313,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
             command.Parameters.AddWithValue("@ExpiryTime", expiryTime);
 
             return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -352,6 +368,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
 
             return holders;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error getting holders for semaphore {SemaphoreName}", semaphoreName);
@@ -385,6 +405,10 @@ public sealed class SqlServerSemaphoreProvider : ISemaphoreProvider
             command.Parameters.AddWithValue("@HolderId", holderId);
 
             return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Follow-up to #141, addressing the three remaining moderate findings from the review of #117.

## 1. Consul: lost session left the service claiming "Holding" forever

`Session.Renew` **throws** `SessionExpiredException` (rather than returning a null response) when the session no longer exists — e.g. after a network partition longer than the session TTL. In `UpdateHeartbeatAsync` the generic catch wrapped it in `SemaphoreProviderException`, so `SemaphoreService` treated it as a transient provider error: it retried, logged a warning, and stayed in `Holding` state indefinitely while the slot was permanently gone (an expired session never renews again).

Now:
- `UpdateHeartbeatAsync` catches `SessionExpiredException`, drops the local session tracking, and returns `false` — the contract signal for "slot lost" — so the service demotes to `Waiting` and re-acquires.
- `TryAcquireAsync`'s renewal path catches it too and falls through to the existing stale-session cleanup + re-acquire path instead of surfacing an error.

> Note: `ConsulLeaderElectionProvider.UpdateHeartbeatAsync` (pre-existing code, line ~182) has the same latent pattern; left out of scope here since this PR targets the semaphore feature branch.

## 2. Redis: multi-key Lua scripts fail with CROSSSLOT on Redis Cluster

Each semaphore uses two keys (`…:holders` and `…:data`) which hash to different cluster slots, so every acquire/release/heartbeat script failed on clustered deployments. The common `{prefix:name}` part is now wrapped in a hash tag so both keys land in the same slot:

```
semaphore:my-sem:holders   →   {semaphore:my-sem}:holders
semaphore:my-sem:data      →   {semaphore:my-sem}:data
```

Harmless on standalone Redis (braces are just part of the key name). The semaphore key layout is unreleased (`feat/semaphore` only), so no data migration is needed.

## 3. SQL Server: cancellation wrapped as a provider failure

Every catch block in `SqlServerSemaphoreProvider` caught `OperationCanceledException` and wrapped it in `SemaphoreProviderException`, so cancelling a call was treated as a retryable transient failure by `SemaphoreService.ExecuteWithRetryAsync` (wasted retry attempts, misleading error logs). Added the `catch (OperationCanceledException) { throw; }` rethrow ahead of each generic catch, matching the PostgreSQL/Redis/Consul/FileSystem providers.

## Tests

No new unit tests: all three fixes are only observable against live infrastructure (an expired Consul session, a Redis Cluster deployment, a cancelled in-flight SQL call) and are covered behaviorally by the existing integration suites. Existing tests exercise the changed code paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D79i3saTKrBEKrhpMuDWv

---
_Generated by [Claude Code](https://claude.ai/code/session_011D79i3saTKrBEKrhpMuDWv)_