### PR TITLE
docs: remove duplicate Testing section, list the semaphore sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,25 +783,13 @@ builder.Services.AddFileSystemSemaphore(
 | Failover | Automatic re-election | Slot becomes available |
 | API | `IsLeader` property | `IsHolding` property |
 
-## Testing
-
-The framework includes comprehensive test coverage:
-
-```bash
-# Run all tests
-dotnet test
-
-# Run specific test project
-dotnet test tests/MultiLock.Tests/
-dotnet test tests/MultiLock.IntegrationTests/
-```
-
 ## Samples
 
 Check out the sample applications:
 
 - **Basic Sample**: `samples/MultiLock.Sample/` - Single provider demonstration
 - **Multi-Provider Demo**: `samples/MultiLock.MultiProvider/` - Multiple instances competing
+- **Semaphore Sample**: `samples/MultiLock.SemaphoreSample/` - Rate-limited workers coordinated by a distributed semaphore
 
 ```bash
 # Run the basic sample with different providers
@@ -817,6 +805,10 @@ dotnet run zookeeper "localhost:2181"
 # Run the multi-provider demo
 cd samples/MultiLock.MultiProvider
 dotnet run
+
+# Run the semaphore sample: dotnet run [provider] [maxConcurrent]
+cd samples/MultiLock.SemaphoreSample
+dotnet run inmemory 3
 ```
 
 ## Testing


### PR DESCRIPTION
Small README cleanup following the #117 merge. The distributed semaphore functionality itself is already fully documented (use cases, quick start, service usage patterns, per-provider registration, configuration options, semaphore-vs-leader-election comparison) — this fixes two blemishes that #117's README changes introduced:

- **Duplicate `## Testing` section**: #117 added a short Testing section right before Samples, shadowing the fuller pre-existing one that documents the Docker-based integration tests. The duplicate is removed; the complete section remains.
- **Missing sample listing**: #117 added `samples/MultiLock.SemaphoreSample/` but didn't list it in the Samples section. It's now listed with its run command (`dotnet run [provider] [maxConcurrent]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D79i3saTKrBEKrhpMuDWv

---
_Generated by [Claude Code](https://claude.ai/code/session_011D79i3saTKrBEKrhpMuDWv)_