### PR TITLE
docs: add Breaking Changes section for v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ A comprehensive .NET framework for implementing **Leader Election** and **Distri
 - **.NET 8.0** or **.NET 10.0**
 - Supported platforms: Windows, Linux, macOS
 
+## Breaking Changes
+
+### v2.0.0
+
+- **Distributed Semaphores** are introduced as a new coordination primitive alongside Leader Election. This is an additive feature and does not change existing leader-election APIs. See [Distributed Semaphores](#distributed-semaphores).
+- **Consul: `SessionLockDelay` validation tightened.** The permitted maximum for `ConsulLeaderElectionOptions.SessionLockDelay` changed from **60 minutes** to **60 seconds**, matching Consul's own upper bound for session lock-delay. A value greater than 60 seconds now throws an `ArgumentException` at startup instead of being accepted.
+
+  ```csharp
+  // No longer valid — throws ArgumentException (was previously allowed):
+  options.SessionLockDelay = TimeSpan.FromMinutes(5);
+
+  // Valid — must be between 0 and 60 seconds (default is 15 seconds):
+  options.SessionLockDelay = TimeSpan.FromSeconds(15);
+  ```
+
+  **Migration:** if you set `SessionLockDelay` above 60 seconds, lower it to 60 seconds or less. Configurations using the default (15 seconds) are unaffected.
+
 ## Architecture Overview
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,12 +26,15 @@ A comprehensive .NET framework for implementing **Leader Election** and **Distri
 - **Consul: `SessionLockDelay` validation tightened.** The permitted maximum for `ConsulLeaderElectionOptions.SessionLockDelay` changed from **60 minutes** to **60 seconds**, matching Consul's own upper bound for session lock-delay. A value greater than 60 seconds now throws an `ArgumentException` at startup instead of being accepted.
 
   ```csharp
-  // No longer valid — throws ArgumentException (was previously allowed):
-  options.SessionLockDelay = TimeSpan.FromMinutes(5);
+  // ❌ Throws ArgumentException at startup (when the provider is constructed) —
+  //    the maximum is now 60 seconds, was previously 60 minutes:
+  var invalid = new ConsulLeaderElectionOptions { SessionLockDelay = TimeSpan.FromMinutes(5) };
 
-  // Valid — must be between 0 and 60 seconds (default is 15 seconds):
-  options.SessionLockDelay = TimeSpan.FromSeconds(15);
+  // ✅ Valid — must be between 0 and 60 seconds (default is 15 seconds):
+  var valid = new ConsulLeaderElectionOptions { SessionLockDelay = TimeSpan.FromSeconds(15) };
   ```
+
+  `SessionLockDelay` is an `init`-only property, so it is set through an object initializer (or configuration binding), not by reassignment.
 
   **Migration:** if you set `SessionLockDelay` above 60 seconds, lower it to 60 seconds or less. Configurations using the default (15 seconds) are unaffected.
 


### PR DESCRIPTION
Adds a **Breaking Changes** section to the README ahead of the v2.0.0 release, placed near the top (right after Requirements) so upgraders see it.

The v2.0.0 entry documents:

- **Consul `SessionLockDelay` validation tightened** — the permitted maximum dropped from 60 minutes to 60 seconds (matching Consul's own limit), so values above 60s now throw an `ArgumentException` at startup. Includes before/after snippets and migration guidance. Configs using the default (15s) are unaffected.
- A note that **Distributed Semaphores** are a new additive feature that doesn't change existing leader-election APIs, linking to the existing section.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D79i3saTKrBEKrhpMuDWv

---
_Generated by [Claude Code](https://claude.ai/code/session_011D79i3saTKrBEKrhpMuDWv)_